### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ C2P supports Compliance and PVP as follows:
 
 C2P reduces the cost to implement the interchange between Compliance artifacts and PVP proprietary artifacts. C2P is extensible to various PVPs through plugin.
 
-## C2P in Go language (deprecated)
-C2P was originally maintained in Go language but now it's maintained in Python. The Go verion is moved to [/go](/go/README.md). 
+## C2P in Go language
+The Go verion is available in the [go directory](/go/README.md). 
 
 ## Install 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img alt="Logo" width="80px" src="./assets/compliance-to-policy-800x800.PNG" style="vertical-align: middle;" /> Compliance-to-Policy (also known as `C2P`)
+# <img alt="Logo" width="50px" src="./assets/compliance-to-policy-800x800.PNG" style="vertical-align: middle;" /> Compliance-to-Policy (also known as `C2P`)
 
 ## Introduction
 


### PR DESCRIPTION
Signed-off-by: Takumi Yanagawa [yana@jp.ibm.com](mailto:yana@jp.ibm.com)

- update logo size consistent with the looks of [compliance-trestle project ](https://github.com/oscal-compass/compliance-trestle/blob/develop/README.md#-compliance-trestle-also-known-as-trestle)
- "deprecated" was bad word. Removed it. 

Related issue: #19