### PR TITLE
Update to compliance-trestle ~= 3.3

### DIFF
--- a/c2p/common/c2p_base_model.py
+++ b/c2p/common/c2p_base_model.py
@@ -20,8 +20,8 @@ import pathlib
 from typing import Any, Dict, Optional, Type, TypeVar
 
 import orjson
-from pydantic import BaseModel
-from pydantic.parse import load_file
+from pydantic.v1 import BaseModel
+from pydantic.v1.parse import load_file
 from trestle.core.base_model import robust_datetime_serialization
 
 import c2p.common.err as err

--- a/c2p/framework/c2p.py
+++ b/c2p/framework/c2p.py
@@ -17,7 +17,7 @@
 import pathlib
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from trestle import __version__ as TRESTLE_VERSION
 from trestle.oscal import OSCAL_VERSION
 from trestle.oscal.assessment_results import (

--- a/c2p/framework/models/c2p_config.py
+++ b/c2p/framework/models/c2p_config.py
@@ -17,7 +17,7 @@
 from enum import Enum
 from typing import Dict, List, Literal, Optional, Union
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from c2p.common.c2p_base_model import C2PBaseModel
 from c2p.framework.models import PVPResult

--- a/c2p/framework/models/policy.py
+++ b/c2p/framework/models/policy.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, List, Optional
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from c2p.common.c2p_base_model import C2PBaseModel
 

--- a/c2p/framework/models/pvp_result.py
+++ b/c2p/framework/models/pvp_result.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from c2p.common.c2p_base_model import C2PBaseModel
 

--- a/c2p/framework/models/raw_result.py
+++ b/c2p/framework/models/raw_result.py
@@ -16,7 +16,7 @@
 
 from typing import Any, Dict, Optional
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from c2p.common.c2p_base_model import C2PBaseModel
 

--- a/c2p/framework/oscal_utils.py
+++ b/c2p/framework/oscal_utils.py
@@ -19,15 +19,15 @@ from enum import Enum
 from typing import Any, Dict, List, Union
 from uuid import uuid4
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from trestle.common.common_types import TypeWithProps
 from trestle.common.list_utils import as_list
-from trestle.oscal.assessment_results import (
+from trestle.oscal.common import (
     ControlSelection,
+    Property,
     ReviewedControls,
     SelectControlById,
 )
-from trestle.oscal.common import Property
 from trestle.oscal.component import ComponentDefinition
 
 from c2p.common.oscal import is_component_type_validation

--- a/c2p/framework/plugin_spec.py
+++ b/c2p/framework/plugin_spec.py
@@ -17,7 +17,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from c2p.framework.models.policy import Policy
 from c2p.framework.models.pvp_result import PVPResult

--- a/c2p/tools/viewer/viewer.py
+++ b/c2p/tools/viewer/viewer.py
@@ -17,7 +17,7 @@
 from typing import Dict, List, Optional
 
 from jinja2 import Template
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from trestle.oscal.assessment_results import AssessmentResults, Observation
 from trestle.oscal.common import Property
 from trestle.oscal.component import ComponentDefinition, DefinedComponent

--- a/plugins_public/plugins/auditree.py
+++ b/plugins_public/plugins/auditree.py
@@ -21,8 +21,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
-from pydantic import Field
-from pydantic.utils import deep_update
+from pydantic.v1 import Field
+from pydantic.v1.utils import deep_update
 
 from c2p.common.logging import getLogger
 from c2p.common.utils import get_dict_safely

--- a/plugins_public/plugins/kyverno.py
+++ b/plugins_public/plugins/kyverno.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 from jinja2 import Template
-from pydantic import Field
+from pydantic.v1 import Field
 
 from c2p.common.err import C2PError
 from c2p.common.logging import getLogger

--- a/plugins_public/plugins/ocm.py
+++ b/plugins_public/plugins/ocm.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, TypeVar
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from c2p.common.err import C2PError
 from c2p.common.logging import getLogger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "compliance-trestle==2.2.1",
+  "compliance-trestle~=3.3",
   "PyGithub==1.58.0",
   "jq==1.6.0",
   "pluggy",

--- a/samples_public/heterogeneous/result_to_compliance.py
+++ b/samples_public/heterogeneous/result_to_compliance.py
@@ -2,10 +2,15 @@ import argparse
 import subprocess
 from typing import Dict, List
 
-from trestle.oscal.assessment_results import AssessmentResults, ControlSelection
+from trestle.oscal.assessment_results import AssessmentResults
 from trestle.oscal.assessment_results import Model as AssessmentResultsRoot
-from trestle.oscal.assessment_results import Result, ReviewedControls, SelectControlById
-from trestle.oscal.common import Metadata
+from trestle.oscal.assessment_results import Result
+from trestle.oscal.common import (
+    ControlSelection,
+    Metadata,
+    ReviewedControls,
+    SelectControlById,
+)
 
 from c2p.framework.oscal_utils import get_datetime, uuid
 

--- a/tests/c2p/framework/test_c2p.py
+++ b/tests/c2p/framework/test_c2p.py
@@ -18,7 +18,7 @@ import json
 import pathlib
 from typing import Any, Dict, Tuple
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from trestle.oscal.assessment_results import AssessmentResults
 
 from c2p.framework.c2p import C2P

--- a/tests/data/framework/c2p/assessment-results.json
+++ b/tests/data/framework/c2p/assessment-results.json
@@ -3,8 +3,8 @@
   "metadata": {
     "title": "TEST Assessment Results",
     "last_modified": "2024-03-22T08:28:11.000+00:00",
-    "version": "2.2.1",
-    "oscal_version": "1.0.4"
+    "version": "3.3.0",
+    "oscal_version": "1.1.2"
   },
   "import_ap": {
     "href": "https://not-available-for-now"


### PR DESCRIPTION
Updates compliance-trestle dependency to enable oscal 1.1.2 document use.