### PR TITLE
feat: add local-definitions and findings (#34)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ build:
 
 .PHONY: install
 install:
-	python -m pip install .
+	python -m pip install -e .
 
 .PHONY: install-dev
 install-dev:
-	python -m pip install ".[dev]"
+	python -m pip install -e ".[dev]"
 
 # Direct dependency is not allowed for Pypi packaging even if the dependant module is defined as extra dependencies. 
 # Workaround: Move to manual installation by make

--- a/c2p/framework/c2p.py
+++ b/c2p/framework/c2p.py
@@ -162,6 +162,8 @@ class C2P:
             start=oscal_utils.get_datetime_str(),
             observations=self._get_observations(pvp_result),
             reviewed_controls=oscal_utils.reviewed_controls(self._component_root.component_definition),
+            local_definitions=pvp_result.local_definitions,
+            findings=pvp_result.findings,
         )
         if pvp_result.links != None:
             result.links = list(map(lambda x: Link(href=x.href, text=x.description), pvp_result.links))
@@ -183,7 +185,10 @@ class C2P:
                     oscal_utils.add_prop(props, 'evaluated-on', subject, ['evaluated_on'])
                     oscal_utils.add_prop(props, 'reason', subject, ['reason'])
                     s = SubjectReference(
-                        subject_uuid=oscal_utils.uuid(), title=subject.title, type=subject.type, props=props
+                        subject_uuid=subject.subject_uuid if subject.subject_uuid else oscal_utils.uuid(),
+                        title=subject.title,
+                        type=subject.type,
+                        props=props,
                     )
                     subjects.append(s)
 
@@ -197,7 +202,7 @@ class C2P:
                 if observation.props != None:
                     props = props + observation.props
                 o = Observation(
-                    uuid=oscal_utils.uuid(),
+                    uuid=observation.uuid if observation.uuid else oscal_utils.uuid(),
                     title=observation.title,
                     description=observation.title,
                     methods=observation.methods,

--- a/c2p/framework/models/pvp_result.py
+++ b/c2p/framework/models/pvp_result.py
@@ -19,8 +19,11 @@ from enum import Enum
 from typing import List, Optional
 
 from pydantic.v1 import Field
+from trestle.oscal.assessment_results import LocalDefinitions1
 
 from c2p.common.c2p_base_model import C2PBaseModel
+from trestle.oscal.assessment_results import LocalDefinitions1
+from trestle.oscal.common import Finding
 
 
 class ResultEnum(str, Enum):
@@ -68,6 +71,11 @@ class Subject(C2PBaseModel):
     A human-oriented identifier reference to a resource. Use type to indicate whether the identified resource is a component, inventory item, location, user, or something else.
     """
 
+    subject_uuid: Optional[str] = Field(
+        None,
+        description="A machine-oriented identifier reference to a component, inventory-item, location, party, user, or resource using it's UUID.",
+        title='Subject Universally Unique Identifier Reference',
+    )
     title: str = Field(title='Name of the object')
     type: str = Field(
         ...,
@@ -89,6 +97,7 @@ class ObservationByCheck(C2PBaseModel):
     Describes an individual observation based on each Check_Id defined in Component Definition.
     """
 
+    uuid: Optional[str] = Field(None)
     title: Optional[str] = Field(
         None,
         description='The title for this observation for the check item. If not given, check id is used.',
@@ -118,6 +127,16 @@ class ObservationByCheck(C2PBaseModel):
 
 class PVPResult(C2PBaseModel):
     observations_by_check: Optional[List[ObservationByCheck]] = Field(None)
+    findings: Optional[List[Finding]] = Field(
+        None,
+        description='Equivalent to the "findings" defined in the OSCAL Assessment Results.',
+        title='Describes an individual finding',
+    )
+    local_definitions: Optional[LocalDefinitions1] = Field(
+        None,
+        description='Equivalent to the "local-definitions" defined in the OSCAL Assessment Results.',
+        title='Local Definitions',
+    )
     links: Optional[List[Link]] = Field(None)
 
 


### PR DESCRIPTION
Signed-off-by: Takumi Yanagawa <yana@jp.ibm.com>

This PR is about https://github.com/oscal-compass/compliance-to-policy/issues/34.

What's the changes:
- enable to add local-definitions and findings to PVP Results
- minor enhancement (Makefile): Changed to "pip install -e" to allow immediate reflection of code changes during development. 
