### PR TITLE
fix: prevent execution of untrusted PR code with elevated privileges

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,7 @@
 name: validate
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -25,9 +25,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with: 
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Signed-off-by: Takumi Yanagawa <yana@jp.ibm.com>

## Description
This GitHub Actions workflow does not require elevated GitHub permissions and only needs to run tests against pull request code. Therefore, the trigger has been changed from `pull_request_target` to
`pull_request` to avoid granting unnecessary permissions.

Additionally, since `pull_request` automatically checks out the pull request head branch, the explicit `repository` / `ref` configuration has been removed.

## Related Issue
#46 