### PR TITLE
feat: add Github Actions DevSecOps pipeline plugin

### DIFF
--- a/c2p/commands/version.py
+++ b/c2p/commands/version.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 """C2P Version Command."""
+
 import argparse
 from importlib.metadata import version
 

--- a/c2p/framework/models/pvp_result.py
+++ b/c2p/framework/models/pvp_result.py
@@ -20,10 +20,9 @@ from typing import List, Optional
 
 from pydantic.v1 import Field
 from trestle.oscal.assessment_results import LocalDefinitions1
+from trestle.oscal.common import Finding
 
 from c2p.common.c2p_base_model import C2PBaseModel
-from trestle.oscal.assessment_results import LocalDefinitions1
-from trestle.oscal.common import Finding
 
 
 class ResultEnum(str, Enum):

--- a/plugins_public/plugins/github_actions.py
+++ b/plugins_public/plugins/github_actions.py
@@ -1,0 +1,466 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright 2024 JC Company / OSCAL Compass Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+C2P Plugin for GitHub Actions DevSecOps Pipeline.
+
+This plugin bridges OSCAL Component Definitions and GitHub Actions pipeline
+results, enabling automated compliance assessment for DevSecOps pipelines.
+
+Supported tools:
+  SAST:    Semgrep, SpotBugs/FindSecBugs, Hadolint, CIS Java Check
+  SCA:     Grype (SBOM + Image), Trivy CIS, Dependency-Track
+  DAST:    OWASP ZAP
+  Secrets: Gitleaks
+  SBOM:    CycloneDX
+  Test:    JUnit, Terratest
+  Runtime: Falco, GuardDuty
+  CI/CD:   GitHub Actions, Cosign, Renovate Bot
+"""
+
+import json
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from c2p.framework.models.policy import Policy, RuleSet
+from c2p.framework.models.pvp_result import (
+    Link,
+    ObservationByCheck,
+    Property,
+    PVPResult,
+    ResultEnum,
+    Subject,
+)
+from c2p.framework.models.raw_result import RawResult
+from c2p.framework.plugin_spec import PluginConfig, PluginSpec
+
+# ── 툴 → OSCAL 통제 매핑 ────────────────────────────────────────────────────
+# 근거: payment-api Component Definition (component-definitions/payment-api-components)
+#       NIST SP 800-53 Rev5 High Baseline
+
+TOOL_TO_CONTROLS: Dict[str, List[str]] = {
+    # Secret Detection
+    'gitleaks': ['ia-5', 'si-3'],
+    # SAST
+    'semgrep': ['si-10', 'sa-11', 'si-3', 'sc-13'],
+    'spotbugs': ['si-10', 'sa-11', 'si-3', 'sc-13'],
+    'hadolint': ['cm-7', 'cm-2'],
+    'cis-java': ['cm-7', 'sc-8', 'sc-13'],
+    # SCA / CVE
+    'grype': ['ra-5', 'si-2', 'sr-3', 'si-3'],
+    'trivy': ['ra-5', 'si-2', 'sr-3', 'si-3'],
+    'dependency-track': ['ra-5', 'si-2', 'sr-3'],
+    # DAST
+    'zap': ['sa-11', 'si-10', 'ac-3'],
+    # SBOM
+    'cyclonedx': ['sr-3', 'ra-5'],
+    # IaC / Config
+    'checkov': ['cm-2', 'cm-7', 'sc-8', 'sc-28', 'au-9', 'ac-6'],
+    'kyverno': ['cm-7', 'ac-3', 'sr-3', 'cm-2'],
+    # CI/CD
+    'github-actions': ['sa-15', 'sa-11', 'sr-3', 'cm-3'],
+    'cosign': ['sr-3', 'si-3', 'cm-2'],
+    'renovate': ['si-2', 'sr-3', 'cm-3'],
+    # Runtime
+    'falco': ['si-3', 'au-2', 'ac-6', 'cm-7'],
+    'guardduty': ['si-3', 'ra-5'],
+    # Test
+    'junit': ['sa-11'],
+    'terratest': ['cm-2', 'cm-3'],
+}
+
+# ── 파일 형식 → 파서 매핑 ────────────────────────────────────────────────────
+SARIF_TOOLS = {'gitleaks', 'semgrep', 'hadolint'}
+JSON_TOOLS = {'grype', 'trivy', 'dependency-track', 'cyclonedx'}
+XML_TOOLS = {'spotbugs', 'junit'}
+TEXT_TOOLS = {'cis-java'}
+HTML_TOOLS = {'zap'}
+
+
+class GitHubActionsPluginConfig(PluginConfig):
+    """Configuration for GitHub Actions C2P Plugin."""
+
+    pipeline_run_url: Optional[str] = None
+    commit_sha: Optional[str] = None
+    actor: Optional[str] = None
+
+
+class GitHubActionsPlugin(PluginSpec):
+    """
+    C2P Plugin for GitHub Actions DevSecOps Pipeline.
+
+    Maps GitHub Actions pipeline tool results to OSCAL Assessment Results,
+    enabling automated continuous compliance for DevSecOps pipelines aligned
+    with NIST SP 800-53, SSDF SP 800-218, and SP 800-204D.
+    """
+
+    def __init__(self, config: Optional[GitHubActionsPluginConfig] = None):
+        self.config = config or GitHubActionsPluginConfig()
+
+    def generate_pvp_policy(self, policy: Policy) -> Dict[str, Any]:
+        """
+        OSCAL Component Definition → GitHub Actions job configuration.
+
+        입력: Policy (OSCAL에서 추출한 rule_sets)
+        출력: 각 툴의 GitHub Actions 설정 딕셔너리
+
+        예: sa-11 통제 → Semgrep job 설정 반환
+        """
+        pvp_policy = {}
+
+        for rule_set in policy.rule_sets or []:
+            tool = rule_set.rule_id.lower()
+            controls = TOOL_TO_CONTROLS.get(tool, [])
+
+            pvp_policy[tool] = {
+                'rule_id': rule_set.rule_id,
+                'check_id': rule_set.check_id,
+                'description': rule_set.rule_description or '',
+                'controls': controls,
+                'config': self._get_tool_config(tool, rule_set),
+            }
+
+        return pvp_policy
+
+    def _get_tool_config(self, tool: str, rule_set: RuleSet) -> Dict[str, Any]:
+        """툴별 GitHub Actions 기본 설정 반환."""
+        configs = {
+            'semgrep': {
+                'action': 'semgrep/semgrep-action@v1',
+                'ruleset': 'p/java p/owasp-top-ten p/secrets p/sql-injection',
+                'fail_on': 'error',
+            },
+            'gitleaks': {
+                'action': 'gitleaks/gitleaks-action@v2',
+                'fetch_depth': 0,
+            },
+            'spotbugs': {
+                'maven_goal': 'spotbugs:check',
+                'threshold': 'High',
+                'effort': 'Max',
+            },
+            'grype': {
+                'action': 'anchore/scan-action@v4',
+                'fail_build': False,
+                'severity_cutoff': 'critical',
+            },
+            'trivy': {
+                'compliance': 'docker-cis-1.6',
+                'format': 'json',
+            },
+            'zap': {
+                'action': 'zaproxy/action-full-scan@v0.10.0',
+                'fail_build': False,
+            },
+            'hadolint': {
+                'action': 'hadolint/hadolint-action@v3.1.0',
+                'failure_threshold': 'error',
+            },
+            'junit': {
+                'maven_goal': 'verify',
+                'coverage_threshold': 0.60,
+            },
+        }
+        return configs.get(tool, {})
+
+    def generate_pvp_result(self, raw_result: RawResult) -> PVPResult:
+        """
+        GitHub Actions 파이프라인 결과 → OSCAL Assessment Results.
+
+        입력: RawResult (툴 결과 파일 내용 + 메타데이터)
+        출력: PVPResult (OSCAL Assessment Results 형태)
+
+        additional_props에서 'tool' 키로 어떤 툴의 결과인지 판단.
+        """
+        tool = raw_result.additional_props.get('tool', '').lower()
+        check_id = raw_result.additional_props.get('check_id', tool)
+        filepath = raw_result.metadata.filepath or ''
+        collected = datetime.now(timezone.utc)
+
+        # 툴별 파서 선택
+        if tool in SARIF_TOOLS:
+            result, reason, props = self._parse_sarif(raw_result.data, tool)
+        elif tool in JSON_TOOLS:
+            result, reason, props = self._parse_json(raw_result.data, tool)
+        elif tool in XML_TOOLS:
+            result, reason, props = self._parse_xml(raw_result.data, tool)
+        elif tool in TEXT_TOOLS:
+            result, reason, props = self._parse_text(raw_result.data, tool)
+        else:
+            result = ResultEnum.Error
+            reason = f'Unknown tool: {tool}'
+            props = []
+
+        # 관련 통제 목록
+        controls = TOOL_TO_CONTROLS.get(tool, [check_id])
+
+        observations = []
+        for control_id in controls:
+            obs = ObservationByCheck(
+                check_id=control_id,
+                title=f'{tool.upper()} - {control_id.upper()}',
+                description=f'Automated assessment of {control_id} via {tool} in GitHub Actions pipeline',
+                methods=['TEST-AUTOMATED'],
+                collected=collected,
+                subjects=[
+                    Subject(
+                        title=f'{tool.upper()} scan result',
+                        type='tool',
+                        resource_id=tool,
+                        result=result,
+                        reason=reason,
+                        evaluated_on=collected,
+                        props=props,
+                    )
+                ],
+                relevant_evidences=(
+                    [
+                        Link(
+                            description=f'{tool} scan result file',
+                            href=filepath or f'{tool}-results',
+                        )
+                    ]
+                    if filepath
+                    else None
+                ),
+                props=[
+                    Property(name='tool', value=tool),
+                    Property(name='pipeline-run', value=self.config.pipeline_run_url or ''),
+                    Property(name='commit-sha', value=self.config.commit_sha or ''),
+                ]
+                + (props or []),
+            )
+            observations.append(obs)
+
+        return PVPResult(observations_by_check=observations)
+
+    # ── 파서들 ──────────────────────────────────────────────────────────────
+
+    def _parse_sarif(self, data: Any, tool: str) -> tuple[ResultEnum, str, List[Property]]:
+        """SARIF 형식 파싱 (Semgrep, Gitleaks, Hadolint)."""
+        try:
+            if isinstance(data, str):
+                data = json.loads(data)
+
+            runs = data.get('runs', [])
+            total_results = 0
+            error_count = 0
+            warning_count = 0
+
+            for run in runs:
+                results = run.get('results', [])
+                total_results += len(results)
+                for r in results:
+                    level = r.get('level', 'warning')
+                    if level == 'error':
+                        error_count += 1
+                    else:
+                        warning_count += 1
+
+            props = [
+                Property(name='total-findings', value=str(total_results)),
+                Property(name='error-findings', value=str(error_count)),
+                Property(name='warning-findings', value=str(warning_count)),
+            ]
+
+            if error_count > 0:
+                return (
+                    ResultEnum.Failure,
+                    f'{tool}: {error_count} error(s), {warning_count} warning(s) found',
+                    props,
+                )
+            elif total_results > 0:
+                return (
+                    ResultEnum.Pass,
+                    f'{tool}: {warning_count} warning(s) found (no blocking errors)',
+                    props,
+                )
+            else:
+                return ResultEnum.Pass, f'{tool}: No findings', props
+
+        except Exception as e:
+            return ResultEnum.Error, f'{tool}: Failed to parse SARIF - {e}', []
+
+    def _parse_json(self, data: Any, tool: str) -> tuple[ResultEnum, str, List[Property]]:
+        """JSON 형식 파싱 (Grype, Trivy, Dependency-Track)."""
+        try:
+            if isinstance(data, str):
+                data = json.loads(data)
+
+            if tool == 'grype':
+                return self._parse_grype_json(data)
+            elif tool == 'trivy':
+                return self._parse_trivy_json(data)
+            else:
+                # 일반 JSON - matches 또는 vulnerabilities 필드 탐색
+                matches = data.get('matches', data.get('vulnerabilities', []))
+                count = len(matches)
+                props = [Property(name='total-findings', value=str(count))]
+                if count > 0:
+                    return ResultEnum.Failure, f'{tool}: {count} finding(s)', props
+                return ResultEnum.Pass, f'{tool}: No findings', props
+
+        except Exception as e:
+            return ResultEnum.Error, f'{tool}: Failed to parse JSON - {e}', []
+
+    def _parse_grype_json(self, data: Any) -> tuple[ResultEnum, str, List[Property]]:
+        """Grype CVE 스캔 결과 파싱."""
+        matches = data.get('matches', [])
+        severity_counts: Dict[str, int] = {}
+
+        for match in matches:
+            severity = match.get('vulnerability', {}).get('severity', 'Unknown')
+            severity_counts[severity] = severity_counts.get(severity, 0) + 1
+
+        critical = severity_counts.get('Critical', 0)
+        high = severity_counts.get('High', 0)
+        medium = severity_counts.get('Medium', 0)
+        total = len(matches)
+
+        props = [
+            Property(name='total-cves', value=str(total)),
+            Property(name='critical-cves', value=str(critical)),
+            Property(name='high-cves', value=str(high)),
+            Property(name='medium-cves', value=str(medium)),
+        ]
+
+        reason = f'Grype: {total} CVE(s) found (Critical:{critical}, High:{high}, Medium:{medium})'
+
+        if critical > 0:
+            return ResultEnum.Failure, reason, props
+        elif total > 0:
+            return ResultEnum.Pass, reason, props
+        return ResultEnum.Pass, 'Grype: No CVEs found', props
+
+    def _parse_trivy_json(self, data: Any) -> tuple[ResultEnum, str, List[Property]]:
+        """Trivy CIS Benchmark 결과 파싱."""
+        summary = data.get('Summary', {})
+        fail_count = summary.get('failCount', 0)
+        pass_count = summary.get('passCount', 0)
+        total = fail_count + pass_count
+
+        props = [
+            Property(name='cis-pass', value=str(pass_count)),
+            Property(name='cis-fail', value=str(fail_count)),
+            Property(name='cis-total', value=str(total)),
+        ]
+
+        if fail_count > 0:
+            return (
+                ResultEnum.Failure,
+                f'Trivy CIS: {fail_count} failure(s), {pass_count} pass(es)',
+                props,
+            )
+        return ResultEnum.Pass, f'Trivy CIS: All {pass_count} checks passed', props
+
+    def _parse_xml(self, data: Any, tool: str) -> tuple[ResultEnum, str, List[Property]]:
+        """XML 형식 파싱 (SpotBugs, JUnit)."""
+        try:
+            if isinstance(data, str):
+                root = ET.fromstring(data)
+            else:
+                return ResultEnum.Error, f'{tool}: XML data must be string', []
+
+            if tool == 'spotbugs':
+                return self._parse_spotbugs_xml(root)
+            elif tool == 'junit':
+                return self._parse_junit_xml(root)
+            else:
+                return ResultEnum.Pass, f'{tool}: Parsed successfully', []
+
+        except Exception as e:
+            return ResultEnum.Error, f'{tool}: Failed to parse XML - {e}', []
+
+    def _parse_spotbugs_xml(self, root: ET.Element) -> tuple[ResultEnum, str, List[Property]]:
+        """SpotBugs XML 결과 파싱."""
+        bugs = root.findall('.//BugInstance')
+        high_bugs = [b for b in bugs if b.get('priority') in ('1', '2')]
+        total = len(bugs)
+
+        props = [
+            Property(name='total-bugs', value=str(total)),
+            Property(name='high-priority-bugs', value=str(len(high_bugs))),
+        ]
+
+        if len(high_bugs) > 0:
+            return (
+                ResultEnum.Failure,
+                f'SpotBugs: {len(high_bugs)} high-priority bug(s) found',
+                props,
+            )
+        return ResultEnum.Pass, f'SpotBugs: {total} total findings (no high priority)', props
+
+    def _parse_junit_xml(self, root: ET.Element) -> tuple[ResultEnum, str, List[Property]]:
+        """JUnit XML 결과 파싱."""
+        # testsuite 또는 testsuites 처리
+        if root.tag == 'testsuites':
+            suites = root.findall('testsuite')
+        else:
+            suites = [root]
+
+        total = 0
+        failures = 0
+        errors = 0
+
+        for suite in suites:
+            total += int(suite.get('tests', 0))
+            failures += int(suite.get('failures', 0))
+            errors += int(suite.get('errors', 0))
+
+        props = [
+            Property(name='total-tests', value=str(total)),
+            Property(name='failures', value=str(failures)),
+            Property(name='errors', value=str(errors)),
+        ]
+
+        if failures > 0 or errors > 0:
+            return (
+                ResultEnum.Failure,
+                f'JUnit: {failures} failure(s), {errors} error(s) out of {total} tests',
+                props,
+            )
+        return ResultEnum.Pass, f'JUnit: All {total} tests passed', props
+
+    def _parse_text(self, data: Any, tool: str) -> tuple[ResultEnum, str, List[Property]]:
+        """텍스트 형식 파싱 (CIS Java Check)."""
+        try:
+            if not isinstance(data, str):
+                data = str(data)
+
+            pass_count = data.count('✅ PASS')
+            fail_count = data.count('❌ FAIL')
+            warn_count = data.count('⚠️  WARN')
+
+            props = [
+                Property(name='pass-count', value=str(pass_count)),
+                Property(name='fail-count', value=str(fail_count)),
+                Property(name='warn-count', value=str(warn_count)),
+            ]
+
+            if fail_count > 0:
+                return (
+                    ResultEnum.Failure,
+                    f'CIS Java: {fail_count} FAIL, {warn_count} WARN, {pass_count} PASS',
+                    props,
+                )
+            return (
+                ResultEnum.Pass,
+                f'CIS Java: {pass_count} PASS, {warn_count} WARN (no failures)',
+                props,
+            )
+
+        except Exception as e:
+            return ResultEnum.Error, f'{tool}: Failed to parse text - {e}', []

--- a/plugins_public/tests/plugins/test_github_actions.py
+++ b/plugins_public/tests/plugins/test_github_actions.py
@@ -1,0 +1,589 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright 2024 JC Company / OSCAL Compass Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""
+Tests for C2P GitHub Actions Plugin.
+
+Tests cover:
+  - generate_pvp_policy(): OSCAL Policy → GitHub Actions config
+  - generate_pvp_result(): Pipeline results → OSCAL Assessment Results
+    - SARIF (Semgrep, Gitleaks, Hadolint)
+    - JSON (Grype, Trivy)
+    - XML (SpotBugs, JUnit)
+    - Text (CIS Java)
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from c2p.framework.models.policy import Policy, RuleSet
+from c2p.framework.models.pvp_result import ResultEnum
+from c2p.framework.models.raw_result import Metadata, RawResult
+from c2p.framework.plugin_spec import PluginSpec
+from plugins_public.plugins.github_actions import (
+    TOOL_TO_CONTROLS,
+    GitHubActionsPlugin,
+    GitHubActionsPluginConfig,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def plugin():
+    """기본 플러그인 인스턴스."""
+    return GitHubActionsPlugin()
+
+
+@pytest.fixture
+def plugin_with_config():
+    """설정이 있는 플러그인 인스턴스."""
+    config = GitHubActionsPluginConfig(
+        pipeline_run_url='https://github.com/s1ns3nz0/jccompany-payment-api/actions/runs/123',
+        commit_sha='abc123def456',
+        actor='s1ns3nz0',
+    )
+    return GitHubActionsPlugin(config=config)
+
+
+@pytest.fixture
+def sarif_no_findings():
+    """발견 없는 SARIF 데이터."""
+    return {'runs': [{'results': []}]}
+
+
+@pytest.fixture
+def sarif_with_error():
+    """에러 발견이 있는 SARIF 데이터."""
+    return {
+        'runs': [
+            {
+                'results': [
+                    {'level': 'error', 'ruleId': 'spring-actuator-dangerous-endpoints'},
+                    {'level': 'warning', 'ruleId': 'test-warning'},
+                ]
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def sarif_warnings_only():
+    """경고만 있는 SARIF 데이터."""
+    return {
+        'runs': [
+            {
+                'results': [
+                    {'level': 'warning', 'ruleId': 'some-warning'},
+                ]
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def grype_no_cves():
+    """CVE 없는 Grype 결과."""
+    return {'matches': []}
+
+
+@pytest.fixture
+def grype_critical_cves():
+    """Critical CVE가 있는 Grype 결과."""
+    return {
+        'matches': [
+            {'vulnerability': {'id': 'CVE-2021-44228', 'severity': 'Critical'}},
+            {'vulnerability': {'id': 'CVE-2022-1234', 'severity': 'High'}},
+            {'vulnerability': {'id': 'CVE-2023-5678', 'severity': 'Medium'}},
+        ]
+    }
+
+
+@pytest.fixture
+def grype_high_only():
+    """High CVE만 있는 Grype 결과 (Critical 없음)."""
+    return {
+        'matches': [
+            {'vulnerability': {'id': 'CVE-2022-9999', 'severity': 'High'}},
+        ]
+    }
+
+
+@pytest.fixture
+def trivy_cis_pass():
+    """CIS Benchmark 전체 통과 Trivy 결과."""
+    return {'Summary': {'passCount': 20, 'failCount': 0}}
+
+
+@pytest.fixture
+def trivy_cis_fail():
+    """CIS Benchmark 실패가 있는 Trivy 결과."""
+    return {'Summary': {'passCount': 15, 'failCount': 5}}
+
+
+@pytest.fixture
+def spotbugs_no_bugs():
+    """버그 없는 SpotBugs XML."""
+    return '<BugCollection version="4.8.3"><SummaryHTML/></BugCollection>'
+
+
+@pytest.fixture
+def spotbugs_high_bugs():
+    """High priority 버그가 있는 SpotBugs XML."""
+    return '''<BugCollection version="4.8.3">
+        <BugInstance type="SQL_INJECTION" priority="1" rank="1">
+            <Class classname="com.jccompany.PaymentService"/>
+        </BugInstance>
+        <BugInstance type="WEAK_CRYPTO" priority="2" rank="5">
+            <Class classname="com.jccompany.SecurityConfig"/>
+        </BugInstance>
+    </BugCollection>'''
+
+
+@pytest.fixture
+def junit_all_pass():
+    """모든 테스트 통과 JUnit XML."""
+    return '''<testsuite tests="11" failures="0" errors="0" time="1.234">
+        <testcase name="testAC3UnauthenticatedBlocked" classname="PaymentApiTest"/>
+        <testcase name="testAC3AuthenticatedAccess" classname="PaymentApiTest"/>
+    </testsuite>'''
+
+
+@pytest.fixture
+def junit_with_failures():
+    """실패가 있는 JUnit XML."""
+    return '''<testsuite tests="11" failures="2" errors="0" time="1.234">
+        <testcase name="testAC3UnauthenticatedBlocked" classname="PaymentApiTest">
+            <failure>Expected 401 but got 200</failure>
+        </testcase>
+    </testsuite>'''
+
+
+@pytest.fixture
+def cis_java_all_pass():
+    """모든 항목 통과 CIS Java 결과."""
+    return """✅ PASS | 원격 디버깅 비활성화 (CM-7)
+✅ PASS | JMX 원격 접속 비활성화 (CM-7)
+✅ PASS | 비루트 사용자 실행 확인 (CM-7, AC-6)
+✅ PASS | 약한 암호화 알고리즘 미사용 (SC-13)
+✅ PASS | H2 콘솔 비활성화 확인 (CM-7)
+✅ PASS | 디버그 모드 비활성화 확인 (CM-7)
+⚠️  WARN | Actuator 엔드포인트 노출 | info endpoint (CM-7)
+✅ PASS | 로깅 설정 존재 (AU-2)
+✅ PASS | SNAPSHOT 버전 미사용 (SR-3)"""
+
+
+@pytest.fixture
+def cis_java_with_failures():
+    """실패가 있는 CIS Java 결과."""
+    return """✅ PASS | 원격 디버깅 비활성화 (CM-7)
+❌ FAIL | TLS 버전 미명시 | 운영환경에서 TLS 1.2+ 명시 필요 (SC-8)
+❌ FAIL | H2 콘솔 비활성화 | 운영환경 H2 콘솔 노출 위험 (CM-7)
+⚠️  WARN | Actuator 엔드포인트 노출 | info endpoint (CM-7)"""
+
+
+def make_raw_result(tool: str, data, filepath: str = '') -> RawResult:
+    """테스트용 RawResult 생성 헬퍼."""
+    return RawResult(
+        metadata=Metadata(filepath=filepath or f'{tool}-results'),
+        data=data,
+        additional_props={'tool': tool, 'check_id': TOOL_TO_CONTROLS[tool][0]},
+    )
+
+
+# ── 기본 구조 테스트 ──────────────────────────────────────────────────────────
+
+
+class TestPluginSpec:
+    """플러그인 스펙 준수 테스트."""
+
+    def test_inherits_plugin_spec(self, plugin):
+        """PluginSpec 상속 확인."""
+        assert isinstance(plugin, PluginSpec)
+
+    def test_has_required_methods(self, plugin):
+        """필수 메서드 존재 확인."""
+        assert hasattr(plugin, 'generate_pvp_policy')
+        assert hasattr(plugin, 'generate_pvp_result')
+
+    def test_default_config(self, plugin):
+        """기본 설정 확인."""
+        assert plugin.config is not None
+        assert plugin.config.pipeline_run_url is None
+
+    def test_custom_config(self, plugin_with_config):
+        """커스텀 설정 확인."""
+        assert plugin_with_config.config.commit_sha == 'abc123def456'
+        assert plugin_with_config.config.actor == 's1ns3nz0'
+
+
+class TestToolMapping:
+    """TOOL_TO_CONTROLS 매핑 테스트."""
+
+    def test_all_required_tools_present(self):
+        """필수 툴이 모두 매핑됐는지 확인."""
+        required = [
+            'gitleaks',
+            'semgrep',
+            'spotbugs',
+            'hadolint',
+            'cis-java',
+            'grype',
+            'trivy',
+            'zap',
+            'cyclonedx',
+            'junit',
+        ]
+        for tool in required:
+            assert tool in TOOL_TO_CONTROLS, f'{tool} missing from TOOL_TO_CONTROLS'
+
+    def test_controls_are_nist_format(self):
+        """통제 ID가 NIST 형식인지 확인 (예: ac-3, sa-11)."""
+        import re
+
+        pattern = re.compile(r'^[a-z]{2}-\d+$')
+        for tool, controls in TOOL_TO_CONTROLS.items():
+            for control in controls:
+                assert pattern.match(control), f"Invalid control ID '{control}' for tool '{tool}'"
+
+    def test_semgrep_controls(self):
+        """Semgrep 통제 매핑 확인."""
+        controls = TOOL_TO_CONTROLS['semgrep']
+        assert 'sa-11' in controls  # Developer Testing
+        assert 'si-10' in controls  # Input Validation
+        assert 'sc-13' in controls  # Cryptographic Protection
+
+    def test_grype_controls(self):
+        """Grype 통제 매핑 확인."""
+        controls = TOOL_TO_CONTROLS['grype']
+        assert 'ra-5' in controls  # Vulnerability Scanning
+        assert 'si-2' in controls  # Flaw Remediation
+        assert 'sr-3' in controls  # Supply Chain
+
+    def test_gitleaks_controls(self):
+        """Gitleaks 통제 매핑 확인."""
+        controls = TOOL_TO_CONTROLS['gitleaks']
+        assert 'ia-5' in controls  # Authenticator Management
+        assert 'si-3' in controls  # Malicious Code Protection
+
+
+# ── generate_pvp_policy() 테스트 ──────────────────────────────────────────────
+
+
+class TestGeneratePvpPolicy:
+    """generate_pvp_policy() 테스트."""
+
+    def test_single_tool(self, plugin):
+        """단일 툴 정책 생성."""
+        policy = Policy(rule_sets=[RuleSet(rule_id='semgrep', check_id='sa-11', rule_description='SAST')])
+        result = plugin.generate_pvp_policy(policy)
+        assert 'semgrep' in result
+        assert result['semgrep']['rule_id'] == 'semgrep'
+        assert result['semgrep']['check_id'] == 'sa-11'
+
+    def test_multiple_tools(self, plugin):
+        """복수 툴 정책 생성."""
+        policy = Policy(
+            rule_sets=[
+                RuleSet(rule_id='semgrep', check_id='sa-11'),
+                RuleSet(rule_id='grype', check_id='ra-5'),
+                RuleSet(rule_id='gitleaks', check_id='ia-5'),
+            ]
+        )
+        result = plugin.generate_pvp_policy(policy)
+        assert len(result) == 3
+        assert 'semgrep' in result
+        assert 'grype' in result
+        assert 'gitleaks' in result
+
+    def test_controls_included(self, plugin):
+        """통제 목록이 결과에 포함되는지 확인."""
+        policy = Policy(rule_sets=[RuleSet(rule_id='grype', check_id='ra-5')])
+        result = plugin.generate_pvp_policy(policy)
+        assert 'ra-5' in result['grype']['controls']
+        assert 'sr-3' in result['grype']['controls']
+
+    def test_tool_config_included(self, plugin):
+        """툴 설정이 결과에 포함되는지 확인."""
+        policy = Policy(rule_sets=[RuleSet(rule_id='semgrep', check_id='sa-11')])
+        result = plugin.generate_pvp_policy(policy)
+        config = result['semgrep']['config']
+        assert 'action' in config
+        assert 'semgrep/semgrep-action' in config['action']
+
+    def test_empty_policy(self, plugin):
+        """빈 정책 처리."""
+        policy = Policy(rule_sets=[])
+        result = plugin.generate_pvp_policy(policy)
+        assert result == {}
+
+    def test_unknown_tool(self, plugin):
+        """알 수 없는 툴 처리 (오류 없이 처리)."""
+        policy = Policy(rule_sets=[RuleSet(rule_id='unknown-tool', check_id='sa-11')])
+        result = plugin.generate_pvp_policy(policy)
+        assert 'unknown-tool' in result
+        assert result['unknown-tool']['controls'] == []
+
+
+# ── generate_pvp_result() SARIF 테스트 ────────────────────────────────────────
+
+
+class TestParseSarif:
+    """SARIF 형식 파싱 테스트 (Semgrep, Gitleaks, Hadolint)."""
+
+    def test_semgrep_no_findings(self, plugin, sarif_no_findings):
+        """Semgrep 발견 없음 → Pass."""
+        raw = make_raw_result('semgrep', sarif_no_findings, 'semgrep.sarif')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Pass
+
+    def test_semgrep_error_findings(self, plugin, sarif_with_error):
+        """Semgrep 에러 발견 → Failure."""
+        raw = make_raw_result('semgrep', sarif_with_error, 'semgrep.sarif')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Failure
+
+    def test_semgrep_warnings_only(self, plugin, sarif_warnings_only):
+        """Semgrep 경고만 → Pass (blocking 아님)."""
+        raw = make_raw_result('semgrep', sarif_warnings_only, 'semgrep.sarif')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Pass
+
+    def test_gitleaks_no_secrets(self, plugin, sarif_no_findings):
+        """Gitleaks 시크릿 없음 → Pass."""
+        raw = make_raw_result('gitleaks', sarif_no_findings, 'gitleaks.sarif')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Pass
+
+    def test_observations_cover_all_controls(self, plugin, sarif_no_findings):
+        """Semgrep 결과가 모든 관련 통제를 커버하는지 확인."""
+        raw = make_raw_result('semgrep', sarif_no_findings)
+        result = plugin.generate_pvp_result(raw)
+        check_ids = {obs.check_id for obs in result.observations_by_check}
+        for control in TOOL_TO_CONTROLS['semgrep']:
+            assert control in check_ids
+
+    def test_evidence_link_included(self, plugin, sarif_no_findings):
+        """증거 파일 링크가 포함되는지 확인."""
+        raw = make_raw_result('semgrep', sarif_no_findings, 'semgrep-results.sarif')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.relevant_evidences is not None
+        assert obs.relevant_evidences[0].href == 'semgrep-results.sarif'
+
+    def test_method_is_test_automated(self, plugin, sarif_no_findings):
+        """방법론이 TEST-AUTOMATED인지 확인 (OSCAL 요구사항)."""
+        raw = make_raw_result('semgrep', sarif_no_findings)
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert 'TEST-AUTOMATED' in obs.methods
+
+    def test_properties_include_tool_name(self, plugin, sarif_no_findings):
+        """툴 이름이 properties에 포함되는지 확인."""
+        raw = make_raw_result('semgrep', sarif_no_findings)
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        prop_names = {p.name for p in (obs.props or [])}
+        assert 'tool' in prop_names
+
+
+# ── generate_pvp_result() JSON 테스트 ────────────────────────────────────────
+
+
+class TestParseGrypeJson:
+    """Grype JSON 파싱 테스트."""
+
+    def test_no_cves_pass(self, plugin, grype_no_cves):
+        """CVE 없음 → Pass."""
+        raw = make_raw_result('grype', grype_no_cves, 'grype.json')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Pass
+
+    def test_critical_cves_failure(self, plugin, grype_critical_cves):
+        """Critical CVE → Failure."""
+        raw = make_raw_result('grype', grype_critical_cves, 'grype.json')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Failure
+
+    def test_high_only_pass(self, plugin, grype_high_only):
+        """High CVE만 있음 → Pass (Critical만 차단)."""
+        raw = make_raw_result('grype', grype_high_only, 'grype.json')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Pass
+
+    def test_severity_counts_in_props(self, plugin, grype_critical_cves):
+        """CVE 심각도 카운트가 properties에 포함되는지 확인."""
+        raw = make_raw_result('grype', grype_critical_cves, 'grype.json')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        prop_values = {p.name: p.value for p in (obs.props or [])}
+        assert 'critical-cves' in prop_values
+        assert prop_values['critical-cves'] == '1'
+        assert prop_values['high-cves'] == '1'
+
+
+class TestParseTrivyJson:
+    """Trivy CIS JSON 파싱 테스트."""
+
+    def test_all_pass(self, plugin, trivy_cis_pass):
+        """CIS 전체 통과 → Pass."""
+        raw = make_raw_result('trivy', trivy_cis_pass, 'trivy.json')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Pass
+
+    def test_with_failures(self, plugin, trivy_cis_fail):
+        """CIS 실패 있음 → Failure."""
+        raw = make_raw_result('trivy', trivy_cis_fail, 'trivy.json')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Failure
+
+    def test_cis_counts_in_props(self, plugin, trivy_cis_fail):
+        """CIS 카운트가 properties에 포함되는지 확인."""
+        raw = make_raw_result('trivy', trivy_cis_fail, 'trivy.json')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        prop_values = {p.name: p.value for p in (obs.props or [])}
+        assert prop_values['cis-fail'] == '5'
+        assert prop_values['cis-pass'] == '15'
+
+
+# ── generate_pvp_result() XML 테스트 ────────────────────────────────────────
+
+
+class TestParseSpotbugsXml:
+    """SpotBugs XML 파싱 테스트."""
+
+    def test_no_bugs_pass(self, plugin, spotbugs_no_bugs):
+        """버그 없음 → Pass."""
+        raw = make_raw_result('spotbugs', spotbugs_no_bugs, 'spotbugs.xml')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Pass
+
+    def test_high_bugs_failure(self, plugin, spotbugs_high_bugs):
+        """High priority 버그 → Failure."""
+        raw = make_raw_result('spotbugs', spotbugs_high_bugs, 'spotbugs.xml')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Failure
+
+    def test_bug_counts_in_props(self, plugin, spotbugs_high_bugs):
+        """버그 카운트가 properties에 포함되는지 확인."""
+        raw = make_raw_result('spotbugs', spotbugs_high_bugs, 'spotbugs.xml')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        prop_values = {p.name: p.value for p in (obs.props or [])}
+        assert prop_values['high-priority-bugs'] == '2'
+
+
+class TestParseJunitXml:
+    """JUnit XML 파싱 테스트."""
+
+    def test_all_pass(self, plugin, junit_all_pass):
+        """모든 테스트 통과 → Pass."""
+        raw = make_raw_result('junit', junit_all_pass, 'junit.xml')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Pass
+
+    def test_with_failures(self, plugin, junit_with_failures):
+        """테스트 실패 → Failure."""
+        raw = make_raw_result('junit', junit_with_failures, 'junit.xml')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Failure
+
+    def test_test_counts_in_props(self, plugin, junit_all_pass):
+        """테스트 카운트가 properties에 포함되는지 확인."""
+        raw = make_raw_result('junit', junit_all_pass, 'junit.xml')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        prop_values = {p.name: p.value for p in (obs.props or [])}
+        assert prop_values['total-tests'] == '11'
+        assert prop_values['failures'] == '0'
+
+
+# ── generate_pvp_result() Text 테스트 ────────────────────────────────────────
+
+
+class TestParseCisJavaText:
+    """CIS Java Check 텍스트 파싱 테스트."""
+
+    def test_all_pass(self, plugin, cis_java_all_pass):
+        """모든 항목 통과 → Pass."""
+        raw = make_raw_result('cis-java', cis_java_all_pass, 'cis-java.txt')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Pass
+
+    def test_with_failures(self, plugin, cis_java_with_failures):
+        """실패 항목 있음 → Failure."""
+        raw = make_raw_result('cis-java', cis_java_with_failures, 'cis-java.txt')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        assert obs.subjects[0].result == ResultEnum.Failure
+
+    def test_counts_in_props(self, plugin, cis_java_with_failures):
+        """카운트가 properties에 포함되는지 확인."""
+        raw = make_raw_result('cis-java', cis_java_with_failures, 'cis-java.txt')
+        result = plugin.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        prop_values = {p.name: p.value for p in (obs.props or [])}
+        assert prop_values['fail-count'] == '2'
+        assert prop_values['warn-count'] == '1'
+        assert prop_values['pass-count'] == '1'
+
+
+# ── 통합 테스트 ───────────────────────────────────────────────────────────────
+
+
+class TestIntegration:
+    """전체 파이프라인 통합 테스트."""
+
+    def test_full_pipeline_assessment(self, plugin_with_config):
+        """전체 파이프라인 결과로 Assessment Results 생성."""
+        pipeline_results = [
+            ('gitleaks', {'runs': [{'results': []}]}, 'gitleaks.sarif'),
+            ('semgrep', {'runs': [{'results': [{'level': 'warning'}]}]}, 'semgrep.sarif'),
+            ('grype', {'matches': []}, 'grype.json'),
+            ('trivy', {'Summary': {'passCount': 20, 'failCount': 0}}, 'trivy.json'),
+        ]
+
+        all_observations = []
+        for tool, data, filepath in pipeline_results:
+            raw = make_raw_result(tool, data, filepath)
+            pvp_result = plugin_with_config.generate_pvp_result(raw)
+            all_observations.extend(pvp_result.observations_by_check)
+
+        # 모든 주요 통제가 커버되는지 확인
+        covered_controls = {obs.check_id for obs in all_observations}
+        assert 'ia-5' in covered_controls  # Gitleaks
+        assert 'sa-11' in covered_controls  # Semgrep
+        assert 'ra-5' in covered_controls  # Grype
+        assert 'si-3' in covered_controls  # Trivy
+
+    def test_config_propagated_to_observations(self, plugin_with_config):
+        """설정값이 observations에 전파되는지 확인."""
+        raw = make_raw_result('semgrep', {'runs': [{'results': []}]})
+        result = plugin_with_config.generate_pvp_result(raw)
+        obs = result.observations_by_check[0]
+        prop_values = {p.name: p.value for p in (obs.props or [])}
+        assert prop_values['commit-sha'] == 'abc123def456'
+        assert 'jccompany-payment-api' in prop_values['pipeline-run']


### PR DESCRIPTION
## Summary
Add a new C2P plugin for GitHub Actions DevSecOps pipelines.

## Motivation
GitHub Actions is the most widely used CI/CD platform. Currently C2P supports Kyverno, OCM, and Auditree, but there is no plugin for GitHub Actions pipelines. This plugin enables automated OSCAL Assessment Results generation from GitHub Actions pipeline tool results.

## Supported Tools
- **Secret Detection**: Gitleaks (SARIF)
- **SAST**: Semgrep, SpotBugs/FindSecBugs (SARIF/XML)
- **SCA/CVE**: Grype, Trivy (JSON)
- **DAST**: OWASP ZAP
- **SBOM**: CycloneDX
- **IaC**: Hadolint, Checkov, CIS Java Check
- **Test**: JUnit, Terratest
- **Runtime**: Falco, GuardDuty
- **CI/CD**: Cosign, Renovate Bot

## NIST 800-53 Control Mapping
Maps 19 pipeline tools to NIST SP 800-53 controls (SA-11, RA-5, SI-10, SR-3, IA-5, CM-7 etc.)

## Testing
41 tests covering all parsers and tool mappings. All existing tests pass.
