### PR TITLE
feat: add Prowler plugin support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ it:
 	python samples_public/ocm/result_to_compliance.py
 	python samples_public/auditree/compliance_to_policy.py
 	python samples_public/auditree/result_to_compliance.py
+	python samples_public/prowler/compliance_to_policy.py
+	python samples_public/prowler/result_to_compliance.py
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img alt="Logo" width="50px" src="https://raw.githubusercontent.com/oscal-compass/compliance-to-policy/main/assets/compliance-to-policy-800x800.PNG" style="vertical-align: middle;" /> Compliance-to-Policy (also known as `C2P`)
 
-Compliance-to-Policy (C2P) is designed to bridge Compliance as Code such as Open Security Controls Assessment Language (OSCAL) and Policy as Code used by Policy Validation Point (PVP). It generates policies in native format of PVP from OSCAL Component Definitions and produces OSCAL Assessment Results from the native assessment results of PVP. C2P can be used both as a command-line tool and a Python library, making it easy and flexible to integrate into your Continuous Compliance pipelines, such as GitHub Actions, Tekton Pipelines, or Agile Authoring Pipelines. It supports multiple PVP engines, including [Kyverno](https://kyverno.io/), [Open Cluster Management Policy Framework](https://open-cluster-management.io/), and the open-source [Auditree](https://auditree.github.io/), through dedicated plugins for each. Custom plugins can be implemented with a small amount of Python code.
+Compliance-to-Policy (C2P) is designed to bridge Compliance as Code such as Open Security Controls Assessment Language (OSCAL) and Policy as Code used by Policy Validation Point (PVP). It generates policies in native format of PVP from OSCAL Component Definitions and produces OSCAL Assessment Results from the native assessment results of PVP. C2P can be used both as a command-line tool and a Python library, making it easy and flexible to integrate into your Continuous Compliance pipelines, such as GitHub Actions, Tekton Pipelines, or Agile Authoring Pipelines. It supports multiple PVP engines, including [Kyverno](https://kyverno.io/), [Open Cluster Management Policy Framework](https://open-cluster-management.io/), the open-source [Auditree](https://auditree.github.io/), and [Prowler](https://github.com/prowler-cloud/prowler), through dedicated plugins for each. Custom plugins can be implemented with a small amount of Python code.
 
 ![C2P Overview](/assets/architecture.png)
 
@@ -37,6 +37,8 @@ Provide seamless integration with compliance frameworks and existing policy engi
     - OCM is a multi-cluster management platform that provides governance of Kubernetes policies. [Its policy framework](https://open-cluster-management.io/concepts/policy/) allows for the validation and enforcement of policies across multiple clusters.
 - [Auditree](https://auditree.github.io/) (for any target, especially well-suited for resources of PaaS/SaaS/IaaS available through REST API.)
     - Auditree is a GitOps based workflow automation that enables the collection and verification of evidence, building a long-term store of evidence in an git "evidence locker." Evidence is gathered by code scripts called "fetchers" and verified by "checks."
+- [Prowler](https://github.com/prowler-cloud/prowler) (for cloud and SaaS estates: AWS, Azure, GCP, Kubernetes, M365, GitHub, Google Workspace)
+    - Prowler is an open-source security scanner that ships its own library of checks. Because the checks already exist, the generated policy is a check selection and its tunable thresholds rather than policy source, and results are read back from Prowler's OCSF output.
 
 Roadmap:
 - [OPA/Gatekeeper](https://github.com/open-policy-agent/gatekeeper) (for Kubernetes resources)
@@ -130,6 +132,7 @@ You may be asked passphrase of SSH key to access to the git repo.
 - [Kyverno](docs/public/kyverno.md)
 - [Open Cluster Management Governance Policy Framework](docs/public/ocm.md)
 - [Auditree](docs/public/auditree.md)
+- [Prowler](docs/public/prowler.md)
 - [Heterogeneous PVPs (mixing Kyverno, OCM Policy, and Auditree)](docs/public/heterogeneous.md)
 
 ## Usage of C2P as a library

--- a/docs/public/prowler.md
+++ b/docs/public/prowler.md
@@ -1,0 +1,121 @@
+# C2P with Prowler
+
+[Prowler](https://github.com/prowler-cloud/prowler) is an open-source security
+scanner covering AWS, Azure, GCP, Kubernetes, M365, GitHub, Google Workspace and
+others. It is used here as a Policy Validation Point (PVP).
+
+Prowler differs from a policy engine such as Kyverno or OCM in one way that
+shapes the plugin: **it ships its own checks**. There are no policy templates to
+render, so `generate_pvp_policy` performs check *selection* rather than policy
+synthesis — it decides which of Prowler's checks run, and with what thresholds.
+
+## Component definition
+
+Prowler is a component of type `Validation` whose title matches
+`C2PConfig.pvp_name`. Its rule sets carry the `Check_Id` values naming Prowler
+checks. Check ids may be written bare (`iam_root_mfa_enabled`) or namespaced
+(`prowler.iam_root_mfa_enabled`) when several tools share a rule; results are
+reported back in whichever form the document used.
+
+`Parameter_Id` values are dotted paths into Prowler's provider-keyed
+configuration, for example `aws.max_console_access_days`. This keeps a threshold
+a check compares against beside the rule it serves, under the same review as the
+control, instead of in scanner configuration held separately.
+
+## Scope: which account, project or resource
+
+OSCAL describes a *kind* of system; an AWS account or a GCP project is an
+*instance* of one. A component definition therefore carries no target, and C2P's
+`Policy` model has no field for one — it answers which checks to run, never
+where to run them.
+
+Scope is supplied through plugin config by whatever runs the scan, which also
+keeps account identifiers and credentials out of documents shared with auditors.
+The same generated `checks.json` is reused across every target; only the scope
+differs.
+
+```bash
+python samples_public/prowler/compliance_to_policy.py -p gcp \
+  -s '{"project-ids": ["prod-1", "prod-2"]}'
+```
+
+```
+prowler gcp --project-ids prod-1 prod-2 --checks-file .../checks.json ...
+```
+
+Flags are validated against the provider actually selected:
+
+| Provider | Scope flags |
+| --- | --- |
+| `aws` | `profile`, `role`, `organizations-role`, `region`, `excluded-regions`, `resource-arns`, `resource-tags` |
+| `gcp` | `project-ids`, `excluded-project-ids`, `organization-id`, `credentials-file`, `impersonate-service-account` |
+| `azure` | `subscription-ids`, `tenant-id`, `azure-resource-groups`, `azure-region` |
+| `kubernetes` | `context`, `namespaces`, `cluster-name`, `kubeconfig-file` |
+| `m365` | `tenant-id`, `region` |
+| `github` | `organizations`, `repositories`, `repo-list-file`, `exclude-workflows` |
+| `googleworkspace` | none — the provider defines no arguments of its own |
+
+Note that AWS has no `--account-id`: the account under scan is whichever the
+credentials resolve to. An unsupported flag is rejected at generation time
+rather than producing a command that fails later, once the compliance content
+has already been reviewed.
+
+## Compliance to Policy
+
+```bash
+python samples_public/prowler/compliance_to_policy.py -o /tmp/prowler-policy
+```
+
+This writes three files:
+
+| File | Purpose |
+| --- | --- |
+| `checks.json` | the check selection, for `prowler <provider> --checks-file` |
+| `config.yaml` | tunable thresholds, for `prowler <provider> --config-file` |
+| `rules.json` | which rule each check serves, read back when results arrive |
+
+and prints the Prowler invocation:
+
+```
+prowler aws --checks-file /tmp/prowler-policy/checks.json \
+  --config-file /tmp/prowler-policy/config.yaml \
+  --output-formats json-ocsf --output-directory .
+```
+
+## Policy to Compliance
+
+```bash
+python samples_public/prowler/result_to_compliance.py -d /tmp/prowler-policy
+```
+
+Prowler's OCSF Detection Findings become one observation per check, with one
+subject per evaluated resource — so a check that passes on 99 resources and
+fails on 1 is not flattened into a bare failure.
+
+Passing `-d` (the directory from the previous step) additionally rolls the check
+results up into one **finding per rule**. Without it the plugin still emits
+observations; it simply has no rule mapping to aggregate against.
+
+### How results are interpreted
+
+| Prowler status | Result | Why |
+| --- | --- | --- |
+| `PASS` | pass | |
+| `FAIL` | failure | |
+| `MANUAL` | error | requires human determination; not evidence of compliance |
+| `MUTED` | error | a mutelist entry is a suppressed failure, with no owner, rationale or expiry recorded. Reporting it as a pass would let scanner configuration silently satisfy a control |
+
+A rule is `satisfied` only when every check serving it reported and every
+evaluated resource passed. The distinction between failed and unproven is kept:
+
+| Outcome | `state` | `reason` |
+| --- | --- | --- |
+| a check failed on some resource | `not-satisfied` | `fail` |
+| a check errored, was muted, or never reported | `not-satisfied` | `other` |
+| all checks passed everywhere | `satisfied` | `pass` |
+
+A check that did not run is not a pass. Treating silence as success is the
+failure mode this guards against.
+
+See [prowler.result.md](./prowler.result.md) for the assessment results this
+produces.

--- a/docs/public/prowler.result.md
+++ b/docs/public/prowler.result.md
@@ -1,0 +1,346 @@
+# Assessment Results from Prowler
+
+Produced by:
+
+```bash
+python samples_public/prowler/compliance_to_policy.py -o /tmp/prowler-policy
+python samples_public/prowler/result_to_compliance.py -d /tmp/prowler-policy
+```
+
+The sample data is chosen so that one run exercises every outcome the plugin can
+produce: a clean pass, a partial failure, a muted finding and a manual check.
+
+| Rule | State | Reason |
+| --- | --- | --- |
+| `aws-root-mfa` | satisfied | `pass` |
+| `aws-console-mfa` | not-satisfied | `fail` — one console user without MFA |
+| `aws-admin-mfa` | not-satisfied | `other` — muted, so suppressed rather than proven |
+| `aws-audit-trail` | not-satisfied | `other` — a manual check, awaiting determination |
+
+```json
+{
+  "assessment-results": {
+    "uuid": "48025a0f-34e0-4b9b-895a-81b5d01ac77d",
+    "metadata": {
+      "title": "Prowler Assessment Results",
+      "last-modified": "2026-08-11T21:22:56+00:00",
+      "version": "3.12.4",
+      "oscal-version": "1.1.3"
+    },
+    "import-ap": {
+      "href": "https://not-available-for-now"
+    },
+    "results": [
+      {
+        "uuid": "f6df859d-ffcb-4709-b566-854b5babb5c0",
+        "title": "Prowler Assessment Results",
+        "description": "OSCAL Assessment Results from Prowler",
+        "start": "2026-08-11T21:22:56+00:00",
+        "reviewed-controls": {
+          "control-selections": [
+            {
+              "include-controls": [
+                {
+                  "control-id": "ia-2.1",
+                  "statement-ids": []
+                },
+                {
+                  "control-id": "ia-2",
+                  "statement-ids": []
+                },
+                {
+                  "control-id": "ac-6.2",
+                  "statement-ids": []
+                },
+                {
+                  "control-id": "au-2",
+                  "statement-ids": []
+                }
+              ]
+            }
+          ]
+        },
+        "observations": [
+          {
+            "uuid": "26e95903-467d-4ab1-9a51-0919690e3a7b",
+            "title": "cloudtrail_multi_region_enabled",
+            "description": "cloudtrail_multi_region_enabled",
+            "props": [
+              {
+                "name": "assessment-rule-id",
+                "value": "aws-audit-trail"
+              },
+              {
+                "name": "assessment-check-id",
+                "value": "cloudtrail_multi_region_enabled"
+              },
+              {
+                "name": "resources-evaluated",
+                "value": "1"
+              }
+            ],
+            "methods": [
+              "AUTOMATED"
+            ],
+            "subjects": [
+              {
+                "subject-uuid": "a8f9eb58-56a8-4858-b904-cc8bdf053dfb",
+                "type": "resource",
+                "title": "AwsCloudTrailTrail main us-east-1",
+                "props": [
+                  {
+                    "name": "resource-id",
+                    "value": "arn:aws:cloudtrail:us-east-1:123456789012:trail/main"
+                  },
+                  {
+                    "name": "result",
+                    "value": "error"
+                  },
+                  {
+                    "name": "evaluated-on",
+                    "value": "2026-08-11T21:22:56+00:00"
+                  },
+                  {
+                    "name": "reason",
+                    "value": "cloudtrail_multi_region_enabled: MANUAL"
+                  }
+                ]
+              }
+            ],
+            "collected": "2026-08-11T21:22:56+00:00"
+          },
+          {
+            "uuid": "eb855f23-adc7-44fa-b296-2fa5e8c6404b",
+            "title": "iam_administrator_access_with_mfa",
+            "description": "iam_administrator_access_with_mfa",
+            "props": [
+              {
+                "name": "assessment-rule-id",
+                "value": "aws-admin-mfa"
+              },
+              {
+                "name": "assessment-check-id",
+                "value": "iam_administrator_access_with_mfa"
+              },
+              {
+                "name": "resources-evaluated",
+                "value": "1"
+              },
+              {
+                "name": "resources-muted",
+                "value": "1"
+              }
+            ],
+            "methods": [
+              "AUTOMATED"
+            ],
+            "subjects": [
+              {
+                "subject-uuid": "218c39a1-eb46-4c95-baed-cb545002cb0b",
+                "type": "resource",
+                "title": "AwsIamGroup admins us-east-1",
+                "props": [
+                  {
+                    "name": "resource-id",
+                    "value": "arn:aws:iam::123456789012:group/admins"
+                  },
+                  {
+                    "name": "result",
+                    "value": "error"
+                  },
+                  {
+                    "name": "evaluated-on",
+                    "value": "2026-08-11T21:22:56+00:00"
+                  },
+                  {
+                    "name": "reason",
+                    "value": "iam_administrator_access_with_mfa: MUTED"
+                  }
+                ]
+              }
+            ],
+            "collected": "2026-08-11T21:22:56+00:00"
+          },
+          {
+            "uuid": "76dd5532-81da-4fd1-92e9-8f4dd79902ac",
+            "title": "iam_root_mfa_enabled",
+            "description": "iam_root_mfa_enabled",
+            "props": [
+              {
+                "name": "assessment-rule-id",
+                "value": "aws-root-mfa"
+              },
+              {
+                "name": "assessment-check-id",
+                "value": "iam_root_mfa_enabled"
+              },
+              {
+                "name": "resources-evaluated",
+                "value": "1"
+              }
+            ],
+            "methods": [
+              "AUTOMATED"
+            ],
+            "subjects": [
+              {
+                "subject-uuid": "17f64fe9-72cf-4a1b-a957-5191246998ea",
+                "type": "resource",
+                "title": "AwsIamUser root us-east-1",
+                "props": [
+                  {
+                    "name": "resource-id",
+                    "value": "arn:aws:iam::123456789012:root"
+                  },
+                  {
+                    "name": "result",
+                    "value": "pass"
+                  },
+                  {
+                    "name": "evaluated-on",
+                    "value": "2026-08-11T21:22:56+00:00"
+                  },
+                  {
+                    "name": "reason",
+                    "value": "iam_root_mfa_enabled: PASS"
+                  }
+                ]
+              }
+            ],
+            "collected": "2026-08-11T21:22:56+00:00"
+          },
+          {
+            "uuid": "8bd8f91e-3115-4183-a224-1eba9c897b64",
+            "title": "iam_user_mfa_enabled_console_access",
+            "description": "iam_user_mfa_enabled_console_access",
+            "props": [
+              {
+                "name": "assessment-rule-id",
+                "value": "aws-console-mfa"
+              },
+              {
+                "name": "assessment-check-id",
+                "value": "iam_user_mfa_enabled_console_access"
+              },
+              {
+                "name": "resources-evaluated",
+                "value": "2"
+              }
+            ],
+            "methods": [
+              "AUTOMATED"
+            ],
+            "subjects": [
+              {
+                "subject-uuid": "c09fb542-a3c3-42fa-8d3c-05928fa22ff1",
+                "type": "resource",
+                "title": "AwsIamUser alice us-east-1",
+                "props": [
+                  {
+                    "name": "resource-id",
+                    "value": "arn:aws:iam::123456789012:user/alice"
+                  },
+                  {
+                    "name": "result",
+                    "value": "pass"
+                  },
+                  {
+                    "name": "evaluated-on",
+                    "value": "2026-08-11T21:22:56+00:00"
+                  },
+                  {
+                    "name": "reason",
+                    "value": "iam_user_mfa_enabled_console_access: PASS"
+                  }
+                ]
+              },
+              {
+                "subject-uuid": "c2c783b4-9a25-469e-83da-8020d2cd62f8",
+                "type": "resource",
+                "title": "AwsIamUser contractor us-east-1",
+                "props": [
+                  {
+                    "name": "resource-id",
+                    "value": "arn:aws:iam::123456789012:user/contractor"
+                  },
+                  {
+                    "name": "result",
+                    "value": "failure"
+                  },
+                  {
+                    "name": "evaluated-on",
+                    "value": "2026-08-11T21:22:56+00:00"
+                  },
+                  {
+                    "name": "reason",
+                    "value": "iam_user_mfa_enabled_console_access: FAIL"
+                  }
+                ]
+              }
+            ],
+            "collected": "2026-08-11T21:22:56+00:00"
+          }
+        ],
+        "findings": [
+          {
+            "uuid": "4561ac7c-c50a-468f-abcf-5e978da29dee",
+            "title": "aws-admin-mfa",
+            "description": "Not proven: iam_administrator_access_with_mfa (error or suppressed)",
+            "target": {
+              "type": "objective-id",
+              "target-id": "aws-admin-mfa",
+              "status": {
+                "state": "not-satisfied",
+                "reason": "other",
+                "remarks": "Not proven: iam_administrator_access_with_mfa (error or suppressed)"
+              }
+            }
+          },
+          {
+            "uuid": "1b7d15af-96bc-4272-9f56-46e5b9b19b0c",
+            "title": "aws-audit-trail",
+            "description": "Not proven: cloudtrail_multi_region_enabled (error or suppressed)",
+            "target": {
+              "type": "objective-id",
+              "target-id": "aws-audit-trail",
+              "status": {
+                "state": "not-satisfied",
+                "reason": "other",
+                "remarks": "Not proven: cloudtrail_multi_region_enabled (error or suppressed)"
+              }
+            }
+          },
+          {
+            "uuid": "9a7994a7-d2f9-416f-8d1c-203498f01dec",
+            "title": "aws-console-mfa",
+            "description": "Failing checks: iam_user_mfa_enabled_console_access",
+            "target": {
+              "type": "objective-id",
+              "target-id": "aws-console-mfa",
+              "status": {
+                "state": "not-satisfied",
+                "reason": "fail",
+                "remarks": "Failing checks: iam_user_mfa_enabled_console_access"
+              }
+            }
+          },
+          {
+            "uuid": "bc36512f-4b84-4af5-a7c1-8a8ab0a6eecc",
+            "title": "aws-root-mfa",
+            "description": "All checks passed on every evaluated resource: iam_root_mfa_enabled",
+            "target": {
+              "type": "objective-id",
+              "target-id": "aws-root-mfa",
+              "status": {
+                "state": "satisfied",
+                "reason": "pass",
+                "remarks": "All checks passed on every evaluated resource: iam_root_mfa_enabled"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/plugins_public/plugins/prowler.py
+++ b/plugins_public/plugins/prowler.py
@@ -1,0 +1,449 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright 2026 John Earle
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import pathlib
+import uuid as uuid_module
+from typing import Any, Dict, List, Optional
+
+import yaml
+from pydantic.v1 import Field
+from trestle.oscal.common import Finding, FindingTarget, ObjectiveStatus
+
+from c2p.common.err import C2PError
+from c2p.common.logging import getLogger
+from c2p.common.utils import get_datetime, get_dict_safely
+from c2p.framework.models import Policy, PVPResult, RawResult
+from c2p.framework.models.pvp_result import (
+    ObservationByCheck,
+    Property,
+    PVPResult,
+    ResultEnum,
+    Subject,
+)
+from c2p.framework.plugin_spec import PluginConfig, PluginSpec
+
+logger = getLogger(__name__)
+
+# Prowler emits OCSF Detection Findings whose status_code is one of
+# PASS / FAIL / MANUAL / MUTED.
+#
+# MUTED maps to Error, not Pass. A muted finding is a failure suppressed by
+# Prowler's mutelist - a decision made outside the compliance artifacts, with
+# no owner, rationale or expiry attached. Reporting it as a pass would let a
+# scanner configuration silently satisfy a control.
+status_dictionary = {
+    'PASS': ResultEnum.Pass,
+    'FAIL': ResultEnum.Failure,
+    'MANUAL': ResultEnum.Error,
+    'MUTED': ResultEnum.Error,
+}
+
+# A component definition may namespace its check ids (e.g.
+# "prowler.iam_root_mfa_enabled") so several tools can coexist in one rule set,
+# or use Prowler's bare ids directly. Both are supported: the prefix is stripped
+# before the id is handed to Prowler, and restored on the way back out, so
+# observations speak the same dialect as the document they will be matched
+# against.
+CHECK_ID_PREFIX = 'prowler.'
+
+# Written by generate_pvp_policy, read back by generate_pvp_result. Policy
+# generation and result collection are separate runs - often separate processes,
+# with the scan in between - so the rule-to-check mapping is recorded on disk in
+# the deliverable directory rather than held in memory.
+CHECKS_FILENAME = 'checks.json'
+RULES_FILENAME = 'rules.json'
+
+# Prowler's tunable thresholds, consumed via `--config-file`. Its schema is
+# keyed by provider at the top level (aws, azure, gcp, kubernetes, github, ...),
+# so a Parameter_Id is the dotted path into that tree, e.g.
+# `aws.max_ebs_snapshots`.
+CONFIG_FILENAME = 'config.yaml'
+
+# Flags that narrow what a scan covers, verified against
+# prowler/providers/<provider>/lib/arguments/arguments.py.
+#
+# Scope is a runtime concern, not a compliance claim: a component definition
+# describes a *kind* of system, while an account, project or bucket is an
+# instance of it. So scope is supplied by the runner through plugin config and
+# never read from OSCAL - which also keeps targets and credentials out of
+# documents that get published to auditors.
+#
+# Note there is no AWS `--account-id`: the account under scan is whichever one
+# the credentials resolve to, selected with --profile or --role.
+SCOPE_FLAGS = {
+    'aws': ['profile', 'role', 'organizations-role', 'region', 'excluded-regions', 'resource-arns', 'resource-tags'],
+    'gcp': [
+        'project-ids',
+        'excluded-project-ids',
+        'organization-id',
+        'credentials-file',
+        'impersonate-service-account',
+    ],
+    'azure': ['subscription-ids', 'tenant-id', 'azure-resource-groups', 'azure-region'],
+    'kubernetes': ['context', 'namespaces', 'cluster-name', 'kubeconfig-file'],
+    'm365': ['tenant-id', 'region'],
+    'github': ['organizations', 'repositories', 'repo-list-file', 'exclude-workflows'],
+    'googleworkspace': [],  # the provider defines no arguments of its own
+}
+
+SUPPORTED_PROVIDERS = [
+    'aws',
+    'azure',
+    'gcp',
+    'kubernetes',
+    'm365',
+    'github',
+    'googleworkspace',
+]
+
+
+class PluginConfigProwler(PluginConfig):
+    provider: str = Field(..., title='Prowler provider (aws, azure, gcp, kubernetes, m365, ...)')
+    deliverable_policy_dir: str = Field(..., title='Path to deliverable (generated) policy directory')
+    output_dir: Optional[str] = Field('.', title='Directory Prowler writes its OCSF output to')
+    scope: Optional[Dict[str, Any]] = Field(
+        None,
+        title='Scope narrowing the scan, as Prowler flags without the leading dashes '
+        "(e.g. {'project-ids': ['prod-1']}). Underscores are accepted in place of dashes.",
+    )
+
+
+class PluginProwler(PluginSpec):
+    """Prowler as a Policy Validation Point.
+
+    Prowler ships its own checks, so policy generation is check *selection*
+    rather than policy synthesis: the rule set determines which of Prowler's
+    checks run. Results arrive as OCSF Detection Findings and are grouped by
+    check id into one observation each, with one subject per evaluated
+    resource.
+    """
+
+    def __init__(self, config: Optional[PluginConfigProwler] = None) -> None:
+        super().__init__()
+        self.config = config
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _to_native_check_id(check_id: str) -> str:
+        return check_id[len(CHECK_ID_PREFIX) :] if check_id.startswith(CHECK_ID_PREFIX) else check_id
+
+    @staticmethod
+    def _check_id_of(finding: Dict[str, Any]) -> str:
+        check_id = get_dict_safely(finding, ['metadata', 'event_code'])
+        if not check_id:
+            raise C2PError(
+                'Unable to determine the check id of a Prowler finding: '
+                'metadata.event_code is missing. Prowler\'s OCSF output format may have changed.'
+            )
+        return check_id
+
+    @staticmethod
+    def _parse_value(value: Optional[str]) -> Any:
+        """Resolve a parameter value as a YAML scalar.
+
+        Prowler's config mixes types, and some values that look numeric are
+        genuinely strings - a Kubernetes version like "1.28" must not become
+        the float 1.28. Rather than guessing, the value is read as YAML, so the
+        author controls the type the same way they would in the config file
+        itself: `1.28` is a float, `"1.28"` is a string, `[a, b]` is a list.
+        Anything YAML cannot parse is kept verbatim as a string.
+        """
+        if value is None:
+            return None
+        try:
+            return yaml.safe_load(value)
+        except yaml.YAMLError:
+            return value
+
+    def _build_config(self, parameters: Optional[List[Any]]) -> Dict[str, Any]:
+        """Nest dotted Parameter_Ids into Prowler's provider-keyed config tree.
+
+        C2P sources parameters from the non-validation component, so in a
+        heterogeneous component definition every plugin is handed every
+        parameter - including ones meant for Kyverno or OCM. Only parameters
+        rooted at this run's provider are ours to act on; the rest are left
+        alone rather than written into a config Prowler would reject.
+        """
+        config: Dict[str, Any] = {}
+        for parameter in parameters if parameters else []:
+            if not parameter.id:
+                continue
+            segments = parameter.id.split('.')
+            if segments[0] != self.config.provider or len(segments) < 2:
+                logger.debug(f"Parameter '{parameter.id}' is not a {self.config.provider} config key; skipping.")
+                continue
+            node = config
+            for segment in segments[:-1]:
+                node = node.setdefault(segment, {})
+                if not isinstance(node, dict):
+                    raise C2PError(
+                        f"Parameter '{parameter.id}' conflicts with another parameter: "
+                        f"'{segment}' is used both as a value and as a group."
+                    )
+            node[segments[-1]] = self._parse_value(parameter.value)
+        return config
+
+    def _scope_args(self) -> List[str]:
+        """Render the configured scope as Prowler arguments."""
+        if not self.config.scope:
+            return []
+        allowed = SCOPE_FLAGS[self.config.provider]
+        args: List[str] = []
+        for key, value in self.config.scope.items():
+            flag = key.lstrip('-').replace('_', '-')
+            if flag not in allowed:
+                raise C2PError(
+                    f"'{flag}' is not a scope flag of the Prowler {self.config.provider} provider. "
+                    + (
+                        f'Supported: {", ".join(allowed)}.'
+                        if allowed
+                        else f'The {self.config.provider} provider takes no scope flags.'
+                    )
+                )
+            values = value if isinstance(value, list) else [value]
+            args.append(f'--{flag} ' + ' '.join(str(v) for v in values))
+        return args
+
+    # ----------------------------------------------------------------- generate
+    def generate_pvp_policy(self, policy: Policy) -> Any:
+        """Write the check selection Prowler should run.
+
+        Emits `checks.json` (consumable via `prowler <provider> --checks-file`)
+        alongside a human-readable `rules.json` recording which rule each check
+        serves, so a result can be traced back to the rule that required it.
+
+        Any parameters rooted at this provider are written to `config.yaml`
+        (`prowler <provider> --config-file`), so a threshold a check compares
+        against is declared in the component definition and reviewed alongside
+        the rule, rather than living in scanner configuration off to one side.
+        """
+        if self.config is None:
+            raise C2PError('PluginConfigProwler is required to generate a Prowler policy.')
+        if self.config.provider not in SUPPORTED_PROVIDERS:
+            raise C2PError(
+                f"Unsupported Prowler provider '{self.config.provider}'. "
+                f'Supported providers: {", ".join(SUPPORTED_PROVIDERS)}'
+            )
+
+        scope_args = self._scope_args()
+
+        deliverable_dir = pathlib.Path(self.config.deliverable_policy_dir)
+        if not deliverable_dir.exists():
+            logger.info(f"The deliverable policy directory '{deliverable_dir}' is not found. Creating...")
+            deliverable_dir.mkdir(parents=True)
+
+        checks: List[str] = []
+        rules: Dict[str, List[str]] = {}
+        for rule_set in policy.rule_sets if policy.rule_sets else []:
+            checks.append(self._to_native_check_id(rule_set.check_id))
+            # Recorded as written in the component definition, so results can be
+            # reported back in the same form the document uses.
+            # A rule may be verified by several checks; C2P delivers those as
+            # separate rule sets sharing a rule_id.
+            rules.setdefault(rule_set.rule_id, [])
+            if rule_set.check_id not in rules[rule_set.rule_id]:
+                rules[rule_set.rule_id].append(rule_set.check_id)
+
+        checks = sorted(set(checks))
+        if not checks:
+            logger.warning('No checks were derived from the component definition.')
+
+        # Prowler reads this as json_file[provider] (lib/check/check.py), so the
+        # list must be keyed by provider. A bare array parses, then fails inside
+        # Prowler's own exception handler and leaves the check set as None.
+        checks_file = deliverable_dir / CHECKS_FILENAME
+        checks_file.write_text(json.dumps({self.config.provider: checks}, indent=2))
+        rules_file = deliverable_dir / RULES_FILENAME
+        rules_file.write_text(json.dumps(rules, indent=2, sort_keys=True))
+
+        # Thresholds a check compares against belong beside the rule they serve,
+        # not in scanner configuration nobody reviews.
+        prowler_config = self._build_config(policy.parameters)
+        config_file = None
+        if prowler_config:
+            config_file = deliverable_dir / CONFIG_FILENAME
+            config_file.write_text(yaml.safe_dump(prowler_config, default_flow_style=False, sort_keys=True))
+            logger.info(f'Wrote {len(prowler_config[self.config.provider])} config parameter(s) to {config_file}')
+
+        logger.info(f'Generated {len(checks)} check(s) for provider {self.config.provider} in {deliverable_dir}')
+        return {
+            'provider': self.config.provider,
+            'checks': checks,
+            'rules': rules,
+            'checks_file': str(checks_file),
+            'config_file': str(config_file) if config_file else None,
+            'config': prowler_config,
+            'scope': ' '.join(scope_args),
+            'command': (
+                f'prowler {self.config.provider} '
+                + (' '.join(scope_args) + ' ' if scope_args else '')
+                + f'--checks-file {checks_file} '
+                + (f'--config-file {config_file} ' if config_file else '')
+                + f'--output-formats json-ocsf --output-directory {self.config.output_dir}'
+            ),
+        }
+
+    # -------------------------------------------------------------------- result
+    def generate_pvp_result(self, raw_result: RawResult) -> PVPResult:
+        """Convert Prowler's OCSF Detection Findings into observations.
+
+        One observation per check; one subject per evaluated resource, so a
+        check that passes on 99 resources and fails on 1 is not reported as a
+        simple failure.
+        """
+        pvp_result: PVPResult = PVPResult()
+        observations: List[ObservationByCheck] = []
+
+        findings = raw_result.data if isinstance(raw_result.data, list) else [raw_result.data]
+
+        # Prowler reports bare ids; map each back to the form the component
+        # definition used, so C2P can match the observation to its rule set.
+        reported_as = {self._to_native_check_id(c): c for c in self._all_check_ids()}
+
+        findings_by_check: Dict[str, List[Dict[str, Any]]] = {}
+        for finding in findings:
+            native = self._check_id_of(finding)
+            findings_by_check.setdefault(reported_as.get(native, native), []).append(finding)
+
+        for check_id, check_findings in sorted(findings_by_check.items()):
+            subjects: List[Subject] = []
+            muted = 0
+            for finding in check_findings:
+                status_code = str(get_dict_safely(finding, 'status_code', '')).upper()
+                if status_code == 'MUTED':
+                    muted = muted + 1
+                result = status_dictionary[status_code] if status_code in status_dictionary else ResultEnum.Error
+
+                resources = get_dict_safely(finding, 'resources')
+                resources = resources if isinstance(resources, list) and resources else [{}]
+                for resource in resources:
+                    name = get_dict_safely(resource, 'name')
+                    uid = get_dict_safely(resource, 'uid')
+                    resource_type = get_dict_safely(resource, 'type', 'resource')
+                    region = get_dict_safely(resource, 'region', '')
+                    subjects.append(
+                        Subject(
+                            title=f'{resource_type} {name if name else uid} {region}'.strip(),
+                            type='resource',
+                            resource_id=uid if uid else (name if name else 'unknown'),
+                            result=result,
+                            reason=get_dict_safely(finding, 'status_detail'),
+                        )
+                    )
+
+            props = [
+                Property(name='assessment-check-id', value=check_id),
+                Property(name='resources-evaluated', value=str(len(subjects))),
+            ]
+            if muted > 0:
+                # Surfaced explicitly: a muted result is suppressed, not passing.
+                props.append(Property(name='resources-muted', value=str(muted)))
+
+            observations.append(
+                ObservationByCheck(
+                    check_id=check_id,
+                    title=check_id,
+                    description=get_dict_safely(check_findings[0], ['finding_info', 'title'], check_id),
+                    methods=['AUTOMATED'],
+                    collected=get_datetime(),
+                    subjects=subjects,
+                    props=props,
+                )
+            )
+
+        pvp_result.observations_by_check = observations
+        findings = self._generate_findings(observations)
+        if findings:
+            pvp_result.findings = findings
+        return pvp_result
+
+    # ------------------------------------------------------------------ findings
+    def _load_rule_mapping(self) -> Dict[str, List[str]]:
+        """Recover the rule -> checks mapping recorded during policy generation."""
+        if self.config is None:
+            return {}
+        rules_file = pathlib.Path(self.config.deliverable_policy_dir) / RULES_FILENAME
+        if not rules_file.exists():
+            logger.info(
+                f"No '{RULES_FILENAME}' in '{self.config.deliverable_policy_dir}'; "
+                'reporting observations without rule-level findings.'
+            )
+            return {}
+        return json.loads(rules_file.read_text())
+
+    def _all_check_ids(self) -> List[str]:
+        """Every check id recorded during policy generation, as the document wrote it."""
+        return [check for checks in self._load_rule_mapping().values() for check in checks]
+
+    def _generate_findings(self, observations: List[ObservationByCheck]) -> List[Finding]:
+        """Roll check observations up into one finding per rule.
+
+        An observation says what a check saw; a finding says whether the rule
+        holds. A rule is satisfied only when every check serving it ran and
+        every evaluated resource passed - one failing resource fails the rule,
+        and a check that errored or was muted leaves the rule unproven rather
+        than passing. Without this the assessment results carry evidence but no
+        judgement, and a reader has to re-derive the verdict by hand.
+        """
+        rule_mapping = self._load_rule_mapping()
+        if not rule_mapping:
+            return []
+
+        results_by_check: Dict[str, List[ResultEnum]] = {
+            o.check_id: [s.result for s in o.subjects] for o in observations
+        }
+
+        findings: List[Finding] = []
+        for rule_id, checks in sorted(rule_mapping.items()):
+            failed: List[str] = []
+            unproven: List[str] = []
+            for check in checks:
+                if check not in results_by_check:
+                    unproven.append(f'{check} (did not report)')
+                    continue
+                results = results_by_check[check]
+                if any(r == ResultEnum.Failure for r in results):
+                    failed.append(check)
+                elif any(r != ResultEnum.Pass for r in results):
+                    unproven.append(f'{check} (error or suppressed)')
+
+            # `reason` is an OSCAL controlled vocabulary (pass / fail / other);
+            # the prose belongs in `remarks`. 'other' is the honest value for a
+            # rule that was neither proven nor disproven.
+            if failed:
+                state, reason = 'not-satisfied', 'fail'
+                remarks = 'Failing checks: ' + ', '.join(sorted(failed))
+            elif unproven:
+                state, reason = 'not-satisfied', 'other'
+                remarks = 'Not proven: ' + '; '.join(sorted(unproven))
+            else:
+                state, reason = 'satisfied', 'pass'
+                remarks = 'All checks passed on every evaluated resource: ' + ', '.join(sorted(checks))
+
+            findings.append(
+                Finding(
+                    uuid=str(uuid_module.uuid4()),
+                    title=rule_id,
+                    description=remarks,
+                    target=FindingTarget(
+                        type='objective-id',
+                        target_id=rule_id,
+                        status=ObjectiveStatus(state=state, reason=reason, remarks=remarks),
+                    ),
+                )
+            )
+        return findings

--- a/plugins_public/tests/data/prowler/component-definition.json
+++ b/plugins_public/tests/data/prowler/component-definition.json
@@ -1,0 +1,248 @@
+{
+  "component-definition": {
+    "uuid": "d9654f94-adee-46c1-a1a5-3fa7f9208cb6",
+    "metadata": {
+      "title": "Prowler sample component definition",
+      "last-modified": "2026-01-01T00:00:00+00:00",
+      "version": "1.0",
+      "oscal-version": "1.1.2"
+    },
+    "components": [
+      {
+        "uuid": "75c54d23-7f9e-4488-a6e8-792e3d302aa8",
+        "type": "Service",
+        "title": "AWS Account",
+        "description": "An AWS account whose IAM and logging posture is under assessment.",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "aws-root-mfa",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "The root account is protected by MFA.",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "aws-console-mfa",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "Every user with console access has MFA enabled.",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Parameter_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "aws.max_console_access_days",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Parameter_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "Maximum days a console credential may go unused.",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Parameter_Value_Alternatives",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "45",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "aws-admin-mfa",
+            "remarks": "rule_set_02"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "Administrative access requires MFA.",
+            "remarks": "rule_set_02"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "aws-audit-trail",
+            "remarks": "rule_set_03"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "CloudTrail records events in every region.",
+            "remarks": "rule_set_03"
+          }
+        ],
+        "control-implementations": [
+          {
+            "uuid": "350e54f7-5503-4bd1-bb58-546f82d02a00",
+            "source": "https://github.com/usnistgov/oscal-content/blob/main/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_HIGH-baseline_profile.json",
+            "description": "NIST Special Publication 800-53 Revision 5 HIGH IMPACT BASELINE",
+            "implemented-requirements": [
+              {
+                "uuid": "397331fa-b9ae-4558-bc7c-3d4f4fe12fc9",
+                "control-id": "ia-2.1",
+                "description": "The root account is protected by MFA.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+                    "value": "aws-root-mfa"
+                  }
+                ]
+              },
+              {
+                "uuid": "73c88ade-a056-46c7-ab6c-c0245fd88d81",
+                "control-id": "ia-2",
+                "description": "Every user with console access has MFA enabled.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+                    "value": "aws-console-mfa"
+                  }
+                ]
+              },
+              {
+                "uuid": "5211da68-f9be-4190-b7ff-4b57493d1444",
+                "control-id": "ac-6.2",
+                "description": "Administrative access requires MFA.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+                    "value": "aws-admin-mfa"
+                  }
+                ]
+              },
+              {
+                "uuid": "af2cf799-888b-41dd-a6c4-c74fdbfefeb1",
+                "control-id": "au-2",
+                "description": "CloudTrail records events in every region.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+                    "value": "aws-audit-trail"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "332f7f9e-fdcd-43be-857d-ef75c85e7ea0",
+        "type": "Validation",
+        "title": "Prowler",
+        "description": "Prowler open-source cloud security scanner.",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "aws-root-mfa",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "The root account is protected by MFA.",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Check_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "iam_root_mfa_enabled",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Check_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "Prowler check iam_root_mfa_enabled.",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "aws-console-mfa",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "Every user with console access has MFA enabled.",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Check_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "iam_user_mfa_enabled_console_access",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Check_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "Prowler check iam_user_mfa_enabled_console_access.",
+            "remarks": "rule_set_01"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "aws-admin-mfa",
+            "remarks": "rule_set_02"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "Administrative access requires MFA.",
+            "remarks": "rule_set_02"
+          },
+          {
+            "name": "Check_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "iam_administrator_access_with_mfa",
+            "remarks": "rule_set_02"
+          },
+          {
+            "name": "Check_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "Prowler check iam_administrator_access_with_mfa.",
+            "remarks": "rule_set_02"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "aws-audit-trail",
+            "remarks": "rule_set_03"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "CloudTrail records events in every region.",
+            "remarks": "rule_set_03"
+          },
+          {
+            "name": "Check_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "cloudtrail_multi_region_enabled",
+            "remarks": "rule_set_03"
+          },
+          {
+            "name": "Check_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+            "value": "Prowler check cloudtrail_multi_region_enabled.",
+            "remarks": "rule_set_03"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins_public/tests/data/prowler/scan.ocsf.json
+++ b/plugins_public/tests/data/prowler/scan.ocsf.json
@@ -1,0 +1,117 @@
+[
+  {
+    "metadata": {
+      "event_code": "iam_root_mfa_enabled",
+      "product": {
+        "name": "Prowler",
+        "version": "5.37.1"
+      }
+    },
+    "status_code": "PASS",
+    "status_detail": "iam_root_mfa_enabled: PASS",
+    "finding_info": {
+      "title": "Root account has MFA enabled",
+      "uid": "prowler-iam_root_mfa_enabled-arn:aws:iam::123456789012:root"
+    },
+    "resources": [
+      {
+        "uid": "arn:aws:iam::123456789012:root",
+        "name": "root",
+        "type": "AwsIamUser",
+        "region": "us-east-1"
+      }
+    ]
+  },
+  {
+    "metadata": {
+      "event_code": "iam_user_mfa_enabled_console_access",
+      "product": {
+        "name": "Prowler",
+        "version": "5.37.1"
+      }
+    },
+    "status_code": "PASS",
+    "status_detail": "iam_user_mfa_enabled_console_access: PASS",
+    "finding_info": {
+      "title": "IAM user has MFA enabled for console access",
+      "uid": "prowler-iam_user_mfa_enabled_console_access-arn:aws:iam::123456789012:user/alice"
+    },
+    "resources": [
+      {
+        "uid": "arn:aws:iam::123456789012:user/alice",
+        "name": "alice",
+        "type": "AwsIamUser",
+        "region": "us-east-1"
+      }
+    ]
+  },
+  {
+    "metadata": {
+      "event_code": "iam_user_mfa_enabled_console_access",
+      "product": {
+        "name": "Prowler",
+        "version": "5.37.1"
+      }
+    },
+    "status_code": "FAIL",
+    "status_detail": "iam_user_mfa_enabled_console_access: FAIL",
+    "finding_info": {
+      "title": "IAM user has MFA enabled for console access",
+      "uid": "prowler-iam_user_mfa_enabled_console_access-arn:aws:iam::123456789012:user/contractor"
+    },
+    "resources": [
+      {
+        "uid": "arn:aws:iam::123456789012:user/contractor",
+        "name": "contractor",
+        "type": "AwsIamUser",
+        "region": "us-east-1"
+      }
+    ]
+  },
+  {
+    "metadata": {
+      "event_code": "iam_administrator_access_with_mfa",
+      "product": {
+        "name": "Prowler",
+        "version": "5.37.1"
+      }
+    },
+    "status_code": "MUTED",
+    "status_detail": "iam_administrator_access_with_mfa: MUTED",
+    "finding_info": {
+      "title": "IAM group members granted AdministratorAccess have MFA enabled",
+      "uid": "prowler-iam_administrator_access_with_mfa-arn:aws:iam::123456789012:group/admins"
+    },
+    "resources": [
+      {
+        "uid": "arn:aws:iam::123456789012:group/admins",
+        "name": "admins",
+        "type": "AwsIamGroup",
+        "region": "us-east-1"
+      }
+    ]
+  },
+  {
+    "metadata": {
+      "event_code": "cloudtrail_multi_region_enabled",
+      "product": {
+        "name": "Prowler",
+        "version": "5.37.1"
+      }
+    },
+    "status_code": "MANUAL",
+    "status_detail": "cloudtrail_multi_region_enabled: MANUAL",
+    "finding_info": {
+      "title": "CloudTrail is enabled in all regions",
+      "uid": "prowler-cloudtrail_multi_region_enabled-arn:aws:cloudtrail:us-east-1:123456789012:trail/main"
+    },
+    "resources": [
+      {
+        "uid": "arn:aws:cloudtrail:us-east-1:123456789012:trail/main",
+        "name": "main",
+        "type": "AwsCloudTrailTrail",
+        "region": "us-east-1"
+      }
+    ]
+  }
+]

--- a/plugins_public/tests/plugins/test_prowler.py
+++ b/plugins_public/tests/plugins/test_prowler.py
@@ -1,0 +1,267 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright 2026 John Earle
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import pathlib
+
+import pytest
+import yaml
+
+from c2p.common.err import C2PError
+from c2p.framework.models import Policy, RawResult
+from c2p.framework.models.policy import Parameter, RuleSet
+from c2p.framework.models.pvp_result import ResultEnum
+from plugins_public.plugins.prowler import PluginConfigProwler, PluginProwler
+
+DATA = pathlib.Path(__file__).parent.parent / 'data' / 'prowler'
+
+
+def _policy() -> Policy:
+    # A rule verified by two checks arrives as two rule sets sharing a rule_id.
+    return Policy(
+        rule_sets=[
+            RuleSet(
+                rule_id='aws-root-mfa',
+                rule_description='Root account carries MFA',
+                check_id='prowler.iam_root_mfa_enabled',
+            ),
+            RuleSet(rule_id='aws-root-mfa', check_id='prowler.iam_root_hardware_mfa_enabled'),
+            RuleSet(rule_id='aws-console-mfa', check_id='iam_user_mfa_enabled_console_access'),
+        ]
+    )
+
+
+def _raw() -> RawResult:
+    return RawResult(data=json.loads((DATA / 'scan.ocsf.json').read_text()))
+
+
+def test_generate_pvp_policy_writes_check_selection(tmp_path):
+    plugin = PluginProwler(PluginConfigProwler(provider='aws', deliverable_policy_dir=str(tmp_path / 'out')))
+    result = plugin.generate_pvp_policy(_policy())
+
+    # The namespace prefix is stripped: Prowler knows only the bare check id.
+    assert result['checks'] == [
+        'iam_root_hardware_mfa_enabled',
+        'iam_root_mfa_enabled',
+        'iam_user_mfa_enabled_console_access',
+    ]
+    # A rule verified by several checks keeps all of them, recorded as the
+    # component definition wrote them so results can be reported back in kind.
+    assert result['rules']['aws-root-mfa'] == [
+        'prowler.iam_root_mfa_enabled',
+        'prowler.iam_root_hardware_mfa_enabled',
+    ]
+    # Prowler reads json_file[provider]; a bare array leaves its check set None.
+    written = json.loads(pathlib.Path(result['checks_file']).read_text())
+    assert written == {'aws': result['checks']}
+
+
+def test_generate_pvp_policy_rejects_unknown_provider(tmp_path):
+    plugin = PluginProwler(PluginConfigProwler(provider='not-a-cloud', deliverable_policy_dir=str(tmp_path / 'out')))
+    with pytest.raises(C2PError):
+        plugin.generate_pvp_policy(_policy())
+
+
+def test_generate_pvp_result_groups_by_check():
+    observations = PluginProwler().generate_pvp_result(_raw()).observations_by_check
+    by_check = {o.check_id: o for o in observations}
+
+    # Four distinct checks in the fixture, one observation each.
+    assert len(observations) == 4
+    # Two findings for the same check collapse into one observation, two subjects.
+    console = by_check['iam_user_mfa_enabled_console_access']
+    assert len(console.subjects) == 2
+    assert {s.result for s in console.subjects} == {ResultEnum.Pass, ResultEnum.Failure}
+
+
+def test_check_ids_are_reported_as_the_document_wrote_them(tmp_path):
+    """Observations must match the component definition's dialect, or C2P drops them.
+
+    Standalone, the plugin reports Prowler's bare ids. After a policy run whose
+    rule sets namespaced them, the same findings come back namespaced.
+    """
+    bare = PluginProwler().generate_pvp_result(_raw()).observations_by_check
+    assert all(not o.check_id.startswith('prowler.') for o in bare)
+
+    plugin = PluginProwler(PluginConfigProwler(provider='aws', deliverable_policy_dir=str(tmp_path / 'out')))
+    plugin.generate_pvp_policy(_policy())  # rule sets use 'prowler.'-prefixed ids
+    namespaced = {o.check_id for o in plugin.generate_pvp_result(_raw()).observations_by_check}
+    assert 'prowler.iam_root_mfa_enabled' in namespaced
+    # A check absent from the rule sets keeps the id Prowler reported.
+    assert 'cloudtrail_multi_region_enabled' in namespaced
+
+
+def test_muted_is_not_reported_as_pass():
+    """A mutelist entry is a suppressed failure, not a satisfied control."""
+    observations = PluginProwler().generate_pvp_result(_raw()).observations_by_check
+    muted = next(o for o in observations if o.check_id == 'iam_administrator_access_with_mfa')
+    assert muted.subjects[0].result == ResultEnum.Error
+    assert any(p.name == 'resources-muted' and p.value == '1' for p in muted.props)
+
+
+def test_manual_is_reported_as_error():
+    observations = PluginProwler().generate_pvp_result(_raw()).observations_by_check
+    manual = next(o for o in observations if o.check_id == 'cloudtrail_multi_region_enabled')
+    assert manual.subjects[0].result == ResultEnum.Error
+
+
+def test_resources_evaluated_is_recorded():
+    """'0 failed' is meaningless without knowing how many were examined."""
+    observations = PluginProwler().generate_pvp_result(_raw()).observations_by_check
+    console = next(o for o in observations if o.check_id == 'iam_user_mfa_enabled_console_access')
+    assert any(p.name == 'resources-evaluated' and p.value == '2' for p in console.props)
+
+
+def test_missing_event_code_raises():
+    """A silent miss would read downstream as 'check not run', not 'adapter broken'."""
+    with pytest.raises(C2PError):
+        PluginProwler().generate_pvp_result(RawResult(data=[{'status_code': 'PASS'}]))
+
+
+def _val(x):
+    return x.value if hasattr(x, 'value') else x
+
+
+def _findings_by_rule(tmp_path):
+    plugin = PluginProwler(PluginConfigProwler(provider='aws', deliverable_policy_dir=str(tmp_path / 'out')))
+    plugin.generate_pvp_policy(_policy())  # records the rule -> checks mapping
+    result = plugin.generate_pvp_result(_raw())
+    return {f.target.target_id: f for f in result.findings}
+
+
+def test_findings_roll_checks_up_to_rules(tmp_path):
+    """Observations say what a check saw; findings say whether the rule holds."""
+    by_rule = _findings_by_rule(tmp_path)
+    assert set(by_rule) == {'aws-root-mfa', 'aws-console-mfa'}
+
+
+def test_one_failing_resource_fails_the_rule(tmp_path):
+    """The console check passes on one user and fails on another."""
+    status = _findings_by_rule(tmp_path)['aws-console-mfa'].target.status
+    assert _val(status.state) == 'not-satisfied'
+    assert _val(status.reason) == 'fail'
+
+
+def test_check_that_did_not_report_leaves_rule_unproven(tmp_path):
+    """A silent check is not a pass. 'other' distinguishes unproven from failed."""
+    status = _findings_by_rule(tmp_path)['aws-root-mfa'].target.status
+    assert _val(status.state) == 'not-satisfied'
+    assert _val(status.reason) == 'other'
+    assert 'did not report' in status.remarks
+
+
+def test_findings_are_omitted_without_a_rule_mapping():
+    """Result collection can run standalone; it degrades to observations only."""
+    assert PluginProwler().generate_pvp_result(_raw()).findings is None
+
+
+def _generate(tmp_path, parameters):
+    plugin = PluginProwler(PluginConfigProwler(provider='aws', deliverable_policy_dir=str(tmp_path / 'out')))
+    policy = _policy()
+    policy.parameters = parameters
+    return plugin.generate_pvp_policy(policy)
+
+
+def test_parameters_nest_into_the_provider_config(tmp_path):
+    result = _generate(tmp_path, [Parameter(id='aws.max_ebs_snapshots', value='50')])
+    assert result['config'] == {'aws': {'max_ebs_snapshots': 50}}
+    written = yaml.safe_load(pathlib.Path(result['config_file']).read_text())
+    assert written == {'aws': {'max_ebs_snapshots': 50}}
+    assert f"--config-file {result['config_file']}" in result['command']
+
+
+def test_parameters_for_other_plugins_are_ignored(tmp_path):
+    """C2P hands every plugin every parameter; only ours belong in our config."""
+    result = _generate(
+        tmp_path,
+        [
+            Parameter(id='aws.max_ebs_snapshots', value='50'),
+            Parameter(id='kubernetes.audit_log_maxage', value='30'),
+            Parameter(id='org.gh.orgs', value='nasa,esa'),
+        ],
+    )
+    assert result['config'] == {'aws': {'max_ebs_snapshots': 50}}
+
+
+def test_parameter_types_follow_yaml_scalar_rules(tmp_path):
+    """A version like "1.28" is a string; unquoted 1.28 is a float."""
+    result = _generate(
+        tmp_path,
+        [
+            Parameter(id='aws.threshold', value='0.3'),
+            Parameter(id='aws.version', value='"1.28"'),
+            Parameter(id='aws.enabled', value='true'),
+            Parameter(id='aws.severities', value='[High, MEDIUM]'),
+        ],
+    )
+    assert result['config']['aws'] == {
+        'threshold': 0.3,
+        'version': '1.28',
+        'enabled': True,
+        'severities': ['High', 'MEDIUM'],
+    }
+
+
+def test_no_parameters_means_no_config_file(tmp_path):
+    result = _generate(tmp_path, [])
+    assert result['config_file'] is None
+    assert '--config-file' not in result['command']
+    assert not (tmp_path / 'out' / 'config.yaml').exists()
+
+
+def _scoped(tmp_path, provider, scope):
+    plugin = PluginProwler(
+        PluginConfigProwler(provider=provider, deliverable_policy_dir=str(tmp_path / 'out'), scope=scope)
+    )
+    return plugin.generate_pvp_policy(_policy())
+
+
+def test_scope_narrows_the_generated_command(tmp_path):
+    result = _scoped(tmp_path, 'gcp', {'project-ids': ['prod-1', 'prod-2']})
+    assert '--project-ids prod-1 prod-2' in result['command']
+
+
+def test_scope_accepts_underscores(tmp_path):
+    result = _scoped(tmp_path, 'kubernetes', {'namespaces': 'kube-system'})
+    assert '--namespaces kube-system' in result['command']
+
+
+def test_aws_account_id_is_rejected(tmp_path):
+    """Prowler has no --account-id; the account follows from the credentials.
+
+    Silently emitting it would produce a command that fails at scan time, long
+    after the compliance content was reviewed.
+    """
+    with pytest.raises(C2PError) as err:
+        _scoped(tmp_path, 'aws', {'account-id': '123456789012'})
+    assert 'account-id' in str(err.value)
+    assert 'profile' in str(err.value)
+
+
+def test_scope_flag_from_another_provider_is_rejected(tmp_path):
+    with pytest.raises(C2PError):
+        _scoped(tmp_path, 'aws', {'project-ids': ['prod-1']})
+
+
+def test_provider_without_scope_flags_says_so(tmp_path):
+    with pytest.raises(C2PError) as err:
+        _scoped(tmp_path, 'googleworkspace', {'organization-id': 'x'})
+    assert 'takes no scope flags' in str(err.value)
+
+
+def test_no_scope_leaves_the_command_unchanged(tmp_path):
+    result = _scoped(tmp_path, 'aws', None)
+    assert result['command'].startswith('prowler aws --checks-file')

--- a/samples_public/prowler/compliance_to_policy.py
+++ b/samples_public/prowler/compliance_to_policy.py
@@ -1,0 +1,66 @@
+import argparse
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+from c2p.framework.c2p import C2P
+from c2p.framework.models.c2p_config import C2PConfig, ComplianceOscal
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
+from plugins_public.plugins.prowler import PluginConfigProwler, PluginProwler
+
+TEST_DATA_DIR = 'plugins_public/tests/data/prowler'
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-c',
+    '--component_definition',
+    type=str,
+    default=f'{TEST_DATA_DIR}/component-definition.json',
+    help=f'Path to component-definition.json (default: {TEST_DATA_DIR}/component-definition.json)',
+    required=False,
+)
+parser.add_argument('-p', '--provider', type=str, default='aws', help='Prowler provider', required=False)
+parser.add_argument(
+    '-o', '--out', type=str, help='Path to output directory (default: system temporary directory)', required=False
+)
+parser.add_argument(
+    '-s',
+    '--scope',
+    type=str,
+    help='JSON object of Prowler scope flags, e.g. \'{"project-ids": ["prod-1"]}\'. '
+    'Scope is a runtime target, so it is supplied here rather than read from OSCAL.',
+    required=False,
+)
+args = parser.parse_args()
+
+tmpdirname = args.out if args.out != None else tempfile.mkdtemp()
+
+# Setup c2p_config
+c2p_config = C2PConfig()
+c2p_config.compliance = ComplianceOscal()
+c2p_config.compliance.component_definition = args.component_definition
+c2p_config.pvp_name = 'Prowler'
+
+# Construct C2P
+c2p = C2P(c2p_config)
+
+# Transform OSCAL (Compliance) to Policy. Prowler ships its own checks, so the
+# generated policy is the check selection and the tunable config, not policy
+# source.
+config = PluginConfigProwler(
+    provider=args.provider,
+    deliverable_policy_dir=tmpdirname,
+    scope=json.loads(args.scope) if args.scope else None,
+)
+generated = PluginProwler(config).generate_pvp_policy(c2p.get_policy())
+
+print('')
+print(f'Generated in {tmpdirname}:')
+for name in sorted(p.name for p in pathlib.Path(tmpdirname).iterdir()):
+    print(f'  {name}')
+print('')
+print('Run Prowler with:')
+print(f"  {generated['command']}")

--- a/samples_public/prowler/result_to_compliance.py
+++ b/samples_public/prowler/result_to_compliance.py
@@ -1,0 +1,67 @@
+import argparse
+import json
+import os
+import pathlib
+import sys
+
+from c2p.framework.c2p import C2P
+from c2p.framework.models import RawResult
+from c2p.framework.models.c2p_config import C2PConfig, ComplianceOscal
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
+from plugins_public.plugins.prowler import PluginConfigProwler, PluginProwler
+
+TEST_DATA_DIR = 'plugins_public/tests/data/prowler'
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-r',
+    '--result',
+    type=str,
+    default=f'{TEST_DATA_DIR}/scan.ocsf.json',
+    help='Path to the Prowler OCSF output (json-ocsf)',
+    required=False,
+)
+parser.add_argument(
+    '-c',
+    '--component_definition',
+    type=str,
+    default=f'{TEST_DATA_DIR}/component-definition.json',
+    help=f'Path to component-definition.json (default: {TEST_DATA_DIR}/component-definition.json)',
+    required=False,
+)
+parser.add_argument(
+    '-d',
+    '--deliverable_policy_dir',
+    type=str,
+    help='Directory written by compliance_to_policy.py. Supplying it lets the '
+    'plugin roll check results up into rule-level findings.',
+    required=False,
+)
+args = parser.parse_args()
+
+# Setup c2p_config
+c2p_config = C2PConfig()
+c2p_config.compliance = ComplianceOscal()
+c2p_config.compliance.component_definition = args.component_definition
+c2p_config.pvp_name = 'Prowler'
+c2p_config.result_title = 'Prowler Assessment Results'
+c2p_config.result_description = 'OSCAL Assessment Results from Prowler'
+
+# Construct C2P
+c2p = C2P(c2p_config)
+
+# Create pvp_result from raw result via plugin
+pvp_raw_result = RawResult(data=json.loads(pathlib.Path(args.result).read_text()))
+plugin = (
+    PluginProwler(PluginConfigProwler(provider='aws', deliverable_policy_dir=args.deliverable_policy_dir))
+    if args.deliverable_policy_dir
+    else PluginProwler()
+)
+pvp_result = plugin.generate_pvp_result(pvp_raw_result)
+
+# Transform pvp_result to OSCAL Assessment Result
+c2p.set_pvp_result(pvp_result)
+oscal_assessment_results = c2p.result_to_oscal()
+
+print(oscal_assessment_results.oscal_serialize_json(pretty=True))


### PR DESCRIPTION
Closes #53 

Prowler is an open-source security scanner covering AWS, Azure, GCP, Kubernetes, M365, GitHub and Google Workspace. This adds it as a Policy Validation Point.

Prowler ships its own checks, so there are no policy templates to render: generate_pvp_policy performs check selection rather than policy synthesis, emitting checks.json for --checks-file and config.yaml for --config-file. Parameter ids are dotted paths into Prowler's provider-keyed configuration, which keeps a threshold a check compares against beside the rule it serves.

Results arrive as OCSF Detection Findings and become one observation per check with one subject per evaluated resource, so a check that passes on 99 resources and fails on 1 is not flattened into a bare failure. MUTED maps to error rather than pass: a mutelist entry is a suppressed failure with no owner, rationale or expiry recorded, and reporting it as a pass would let scanner configuration silently satisfy a control.

When the deliverable policy directory is supplied, check results are also rolled up into one finding per rule, distinguishing a rule that failed from one that was never proven.

Scan scope is supplied through plugin config rather than read from OSCAL: a component definition describes a kind of system, while an account or project is an instance of one. Scope flags are validated against the selected provider, so an unsupported flag is rejected at generation time instead of producing a command that fails at scan time.

